### PR TITLE
Backfill migration history instead of just deleting dev row

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,20 +33,23 @@ jobs:
         working-directory: /var/www/polymer
         run: pnpm install --no-frozen-lockfile
 
-      # --- ONE-TIME CLEANUP: remove dev migration row that causes interactive prompt ---
-      - name: Clean dev migration row
+      # --- ONE-TIME CLEANUP: mark existing migrations as applied (remove after first successful deploy) ---
+      - name: Backfill migration history
         env:
           DATABASE_URL: "${{ secrets.DATABASE_URL }}"
         run: |
-          psql "$DATABASE_URL" -c "DELETE FROM payload_migrations WHERE batch = -1;" || true
-          # Self-remove: strip this step from the workflow so it doesn't run again
-          sed -i '/# --- ONE-TIME CLEANUP/,/sed -i.*ONE-TIME CLEANUP/d' .github/workflows/deploy.yml
-          cd ${{ github.workspace }}
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .github/workflows/deploy.yml
-          git diff --cached --quiet || git commit -m "chore: remove one-time dev migration cleanup step"
-          git push origin main || true
+          psql "$DATABASE_URL" <<'SQL'
+          DELETE FROM payload_migrations WHERE batch = -1;
+          INSERT INTO payload_migrations (name, batch, updated_at, created_at)
+          VALUES
+            ('20260211_224237_initial_baseline', 1, NOW(), NOW()),
+            ('20260213_223303_remove_copy_workflow', 1, NOW(), NOW()),
+            ('20260217_015404_add_photographer_to_media', 1, NOW(), NOW()),
+            ('20260310_211734_add_user_slug', 1, NOW(), NOW()),
+            ('20260316_144021_add_layout_top4', 1, NOW(), NOW()),
+            ('20260316_145613_remove_editorial_section', 1, NOW(), NOW())
+          ON CONFLICT DO NOTHING;
+          SQL
 
       - name: Run Migrations
         working-directory: /var/www/polymer


### PR DESCRIPTION
The previous cleanup only deleted the dev row (batch=-1), leaving no migration history. Payload then tried to run all migrations from scratch against tables that already exist, causing CREATE TYPE/TABLE errors.

Now inserts records for all 6 existing migrations so Payload knows they're already applied. Uses ON CONFLICT DO NOTHING so it's safe to rerun. Dropped the self-removal git push since branch protection on main blocks it — remove this step manually after first successful deploy.

https://claude.ai/code/session_01TUEEiVpt3i6qKV2qmpuKTv