### PR TITLE
Fix missing article titles in layout editors

### DIFF
--- a/components/Dashboard/FeaturesLayoutEditor/index.tsx
+++ b/components/Dashboard/FeaturesLayoutEditor/index.tsx
@@ -693,7 +693,7 @@ export function FeaturesLayoutEditor() {
       try {
         const artRes = await fetch(
           '/api/articles?where[section][equals]=features&where[_status][equals]=published&sort=-publishedDate&limit=100&depth=1' +
-          '&select[title]=true&select[slug]=true&select[section]=true&select[publishedDate]=true' +
+          '&select[title]=true&select[plainTitle]=true&select[slug]=true&select[section]=true&select[publishedDate]=true' +
           '&select[createdAt]=true&select[featuredImage]=true&select[subdeck]=true&select[kicker]=true' +
           '&select[authors]=true&select[writeInAuthors]=true',
         );

--- a/components/Dashboard/LayoutEditor/index.tsx
+++ b/components/Dashboard/LayoutEditor/index.tsx
@@ -1362,7 +1362,7 @@ export function LayoutEditor() {
         const creatingNewLayout = isCreateRoute();
         const artRes = await fetch(
           '/api/articles?where[_status][equals]=published&sort=-publishedDate&limit=100&depth=1' +
-          '&select[title]=true&select[slug]=true&select[section]=true&select[publishedDate]=true' +
+          '&select[title]=true&select[plainTitle]=true&select[slug]=true&select[section]=true&select[publishedDate]=true' +
           '&select[createdAt]=true&select[featuredImage]=true&select[subdeck]=true&select[kicker]=true' +
           '&select[authors]=true&select[writeInAuthors]=true',
         );

--- a/components/Dashboard/OpinionLayoutEditor/index.tsx
+++ b/components/Dashboard/OpinionLayoutEditor/index.tsx
@@ -391,7 +391,7 @@ export function OpinionLayoutEditor() {
         // Fetch opinion articles
         const artRes = await fetch(
           '/api/articles?where[section][equals]=opinion&where[_status][equals]=published&sort=-publishedDate&limit=100&depth=1' +
-          '&select[title]=true&select[slug]=true&select[section]=true&select[publishedDate]=true' +
+          '&select[title]=true&select[plainTitle]=true&select[slug]=true&select[section]=true&select[publishedDate]=true' +
           '&select[createdAt]=true&select[featuredImage]=true&select[subdeck]=true&select[kicker]=true' +
           '&select[authors]=true&select[writeInAuthors]=true&select[opinionType]=true',
         );


### PR DESCRIPTION
## Summary
- Add `plainTitle` to API select fields in Opinion, Features, and Homepage layout editors
- All three editors were fetching articles without `plainTitle`, causing titles to render as blank in slots and the article pool

## Test plan
- [ ] Open Opinion Layout editor — verify article titles appear in slots and pool
- [ ] Open Features Layout editor — verify same
- [ ] Open Homepage Layout editor — verify same