### PR TITLE
fix: return 410 Gone for unpublished articles

### DIFF
--- a/app/api/article-status/route.ts
+++ b/app/api/article-status/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { getPayload } from 'payload'
+import config from '@/payload.config'
+
+export const runtime = 'nodejs'
+export const revalidate = 60
+
+const VALID_SECTIONS = new Set(['news', 'sports', 'features', 'opinion'])
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const section = searchParams.get('section')
+  const slug = searchParams.get('slug')
+
+  if (!section || !slug) {
+    return NextResponse.json({ error: 'missing params' }, { status: 400 })
+  }
+  if (!VALID_SECTIONS.has(section)) {
+    return NextResponse.json({ gone: false })
+  }
+
+  const payload = await getPayload({ config })
+  const result = await payload.find({
+    collection: 'articles',
+    where: {
+      and: [
+        { slug: { equals: slug } },
+        { section: { equals: section } },
+      ],
+    },
+    limit: 1,
+    depth: 0,
+    // overrideAccess lets us see unpublished rows — without it, the anonymous
+    // read rule would hide them and we'd never be able to distinguish
+    // "never existed" from "exists but unpublished".
+    overrideAccess: true,
+  })
+
+  const article = result.docs[0] as ({ _status?: string } | undefined)
+  if (!article) {
+    return NextResponse.json({ gone: false })
+  }
+
+  const status = article._status
+  return NextResponse.json({ gone: status !== 'published' })
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,47 @@
+import { NextResponse, type NextRequest } from 'next/server'
+
+// Article URLs look like /:section/:year/:month/:slug — the middleware only
+// acts on URLs that match that shape. Anything else passes straight through.
+const ARTICLE_URL_RE = /^\/([a-z]+)\/(\d{4})\/(\d{2})\/([a-z0-9][a-z0-9-]*)\/?$/
+
+export async function middleware(req: NextRequest) {
+  const match = req.nextUrl.pathname.match(ARTICLE_URL_RE)
+  if (!match) return NextResponse.next()
+
+  const [, section, year, month, slug] = match
+  const params = new URLSearchParams({ section, year, month, slug })
+
+  try {
+    const statusRes = await fetch(
+      `${req.nextUrl.origin}/api/article-status?${params.toString()}`,
+      { next: { revalidate: 60, tags: [`article-status:${slug}`] } },
+    )
+    if (!statusRes.ok) return NextResponse.next()
+    const data = (await statusRes.json()) as { gone?: boolean }
+    if (data.gone) {
+      // 410 Gone tells search engines the URL is permanently removed so they
+      // de-index faster than they would from a bare 404.
+      return new NextResponse('Gone — this article has been unpublished.', {
+        status: 410,
+        headers: {
+          'Content-Type': 'text/plain; charset=utf-8',
+          'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=600',
+        },
+      })
+    }
+  } catch {
+    // If the status check fails for any reason, don't break the page — fall
+    // through and let the normal page handler render (which will 404 on miss).
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: [
+    // Skip everything we definitely don't want to intercept. The ARTICLE_URL_RE
+    // above is the real filter; this matcher just avoids invoking middleware
+    // on static assets and known non-article paths.
+    '/((?!_next/|api/|admin/|favicon|robots\\.txt|sitemap|feed|logo|manifest).*)',
+  ],
+}


### PR DESCRIPTION
Closes #106.

## Summary

- Adds \`middleware.ts\` that intercepts article-shaped URLs (\`/:section/:year/:month/:slug\`) and returns **410 Gone** when the article exists but is not published. Anything else falls through to the normal page handler.
- Adds \`app/api/article-status\` that the middleware calls. It uses \`overrideAccess: true\` to see unpublished rows and returns only a boolean (no draft content is ever exposed).
- Response is cached (\`next: { revalidate: 60 }\`) so publish/unpublish takes effect within a minute without hammering Payload.

## Why

Unpublished articles were returning 404, which Google treats as a soft signal. The URLs stay indexed for weeks. 410 is the explicit "permanently removed" status, and search engines de-index much faster.

## Test plan

- [ ] Publish an article, visit its URL → 200
- [ ] Unpublish that article, visit the URL → **410 Gone**
- [ ] Visit a URL with an article-shaped path that never existed → 404 (page handler)
- [ ] Visit non-article URLs (\`/\`, \`/about\`, \`/opinion/more-in-opinion\`, \`/api/health\`, \`/feed\`) → unaffected
- [ ] After unpublish, wait ≥60s and confirm the 410 persists (cache revalidation works)