### PR TITLE
fix: wire up the News 'More' button and add /news/more-in-news

### DIFF
--- a/app/(frontend)/news/more-in-news/page.tsx
+++ b/app/(frontend)/news/more-in-news/page.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { getPayload } from 'payload';
+import config from '@/payload.config';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+import NewsListPage from '@/components/News/NewsListPage';
+import { formatArticle } from '@/utils/formatArticle';
+import type { Article as ComponentArticle } from '@/components/FrontPage/types';
+import type { Metadata } from 'next';
+import { getSeo } from '@/lib/getSeo';
+
+export const revalidate = 60;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const seo = await getSeo()
+
+  return {
+    title: seo.pages.newsMoreTitle,
+    description: seo.pages.newsMoreDescription,
+    alternates: { canonical: '/news/more-in-news' },
+  }
+}
+
+export default async function MoreInNewsPage() {
+  const payload = await getPayload({ config });
+
+  const response = await payload.find({
+    collection: 'articles',
+    where: {
+      and: [
+        { section: { equals: 'news' } },
+        { _status: { equals: 'published' } },
+      ],
+    },
+    sort: '-publishedDate',
+    limit: 200,
+    depth: 1,
+    select: {
+      title: true,
+      slug: true,
+      subdeck: true,
+      featuredImage: true,
+      section: true,
+      kicker: true,
+      publishedDate: true,
+      createdAt: true,
+      authors: true,
+    },
+  });
+
+  const articles = response.docs
+    .map((a) => formatArticle(a))
+    .filter((a): a is ComponentArticle => a !== null);
+
+  return (
+    <main className="min-h-screen bg-bg-main transition-colors duration-300">
+      <Header />
+      <NewsListPage title="More in News" articles={articles} />
+      <Footer />
+    </main>
+  );
+}

--- a/collections/Seo.ts
+++ b/collections/Seo.ts
@@ -91,6 +91,8 @@ export const Seo: GlobalConfig = {
         longText('opinionEditorialsDescription', 'Opinion Editorials Description', 'Used for the /opinion/editorials page description.'),
         shortText('opinionMoreTitle', 'More in Opinion Title', 'Used for the /opinion/more-in-opinion page title.'),
         longText('opinionMoreDescription', 'More in Opinion Description', 'Used for the /opinion/more-in-opinion page description.'),
+        shortText('newsMoreTitle', 'More in News Title', 'Used for the /news/more-in-news page title.'),
+        longText('newsMoreDescription', 'More in News Description', 'Used for the /news/more-in-news page description.'),
       ],
     },
     {

--- a/components/News/NewsListPage.tsx
+++ b/components/News/NewsListPage.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import React, { useState } from "react";
+import Image from "next/image";
+import TransitionLink from "@/components/TransitionLink";
+import { getArticleUrl } from "@/utils/getArticleUrl";
+import type { Article } from "@/components/FrontPage/types";
+import { Byline } from "@/components/FrontPage/Byline";
+
+const PAGE_SIZE = 10;
+
+export default function NewsListPage({
+  title,
+  articles,
+}: {
+  title: string;
+  articles: Article[];
+}) {
+  const [page, setPage] = useState(1);
+
+  const totalPages = Math.ceil(articles.length / PAGE_SIZE);
+  const start = (page - 1) * PAGE_SIZE + 1;
+  const end = Math.min(page * PAGE_SIZE, articles.length);
+  const visible = articles.slice(start - 1, end);
+
+  return (
+    <div style={{ maxWidth: 1280, margin: "0 auto", padding: "20px 30px 64px" }}>
+      <div className="flex items-baseline justify-between mt-6 mb-8">
+        <h1
+          className="font-meta uppercase tracking-[0.04em] text-text-main"
+          style={{ fontSize: 40, fontWeight: 400, lineHeight: 1 }}
+        >
+          {title}
+        </h1>
+        <TransitionLink
+          href="/news"
+          className="font-meta text-[14px] uppercase tracking-[0.08em] text-accent hover:underline transition-colors"
+        >
+          &larr; Back to News
+        </TransitionLink>
+      </div>
+
+      {/* Article list */}
+      <div className="flex flex-col">
+        {visible.map((article) => (
+          <TransitionLink
+            key={article.id}
+            href={getArticleUrl(article)}
+            className="group flex gap-5 py-5 border-b border-rule"
+          >
+            {article.image && (
+              <div
+                className="relative overflow-hidden shrink-0"
+                style={{ width: 180, aspectRatio: "3/2" }}
+              >
+                <Image
+                  src={article.image}
+                  alt={article.imageTitle || ""}
+                  fill
+                  className="object-cover"
+                  sizes="180px"
+                />
+              </div>
+            )}
+            <div className="flex flex-col justify-center">
+              <h2 className="font-copy font-medium leading-[1.15] text-[22px] text-text-main transition-colors">
+                {article.richTitle || article.title}
+              </h2>
+              <Byline author={article.author} date={article.date} className="text-[13px]" />
+              {article.excerpt && (
+                <p className="mt-1 font-meta text-[14px] leading-[1.5] text-text-muted line-clamp-2">
+                  {article.excerpt}
+                </p>
+              )}
+            </div>
+          </TransitionLink>
+        ))}
+      </div>
+
+      {/* Bottom controls */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between mt-8">
+          <span className="font-meta text-[13px] uppercase tracking-[0.08em] text-text-muted">
+            {start}–{end} of {articles.length}
+          </span>
+          <div className="flex items-center gap-3">
+            <button
+              onClick={() => { setPage((p) => Math.max(1, p - 1)); window.scrollTo({ top: 0, behavior: 'smooth' }); }}
+              disabled={page === 1}
+              className="font-meta text-[13px] uppercase tracking-[0.04em] px-3 py-1.5 rounded transition-colors disabled:opacity-30 text-text-main hover:text-accent"
+            >
+              &larr; Prev
+            </button>
+            <span className="font-meta text-[13px] text-text-muted">
+              {page} / {totalPages}
+            </span>
+            <button
+              onClick={() => { setPage((p) => Math.min(totalPages, p + 1)); window.scrollTo({ top: 0, behavior: 'smooth' }); }}
+              disabled={page === totalPages}
+              className="font-meta text-[13px] uppercase tracking-[0.04em] px-3 py-1.5 rounded transition-colors disabled:opacity-30 text-text-main hover:text-accent"
+            >
+              Next &rarr;
+            </button>
+          </div>
+        </div>
+      )}
+      {totalPages <= 1 && articles.length > 0 && (
+        <div className="mt-8">
+          <span className="font-meta text-[13px] uppercase tracking-[0.08em] text-text-muted">
+            {articles.length} article{articles.length !== 1 ? 's' : ''}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/News/NewsSectionPage.tsx
+++ b/components/News/NewsSectionPage.tsx
@@ -206,7 +206,7 @@ export default function NewsSectionPage({
                 {group.label}
               </h2>
               <TransitionLink
-                href={group.kickers ? `/search?q=${encodeURIComponent(group.kickers[0])}` : `/news`}
+                href={group.kickers ? `/search?q=${encodeURIComponent(group.kickers[0])}` : `/news/more-in-news`}
                 className="font-meta text-[14px] uppercase tracking-[0.08em] text-accent hover:underline transition-colors"
               >
                 More &rarr;

--- a/lib/getSeo.ts
+++ b/lib/getSeo.ts
@@ -34,6 +34,8 @@ const PAGE_FALLBACKS = {
   opinionEditorialsDescription: 'Staff editorials, editorial notebooks, and endorsements from The Polytechnic.',
   opinionMoreTitle: 'More in Opinion',
   opinionMoreDescription: 'General opinion pieces and letters to the editor from The Polytechnic.',
+  newsMoreTitle: 'More in News',
+  newsMoreDescription: 'All news articles from The Polytechnic.',
 }
 
 const SECTION_FALLBACKS = {

--- a/migrations/20260424_000000_add_news_more_seo_fields.ts
+++ b/migrations/20260424_000000_add_news_more_seo_fields.ts
@@ -1,0 +1,19 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "seo" ADD COLUMN IF NOT EXISTS "pages_news_more_title" varchar;
+    ALTER TABLE "seo" ADD COLUMN IF NOT EXISTS "pages_news_more_description" varchar;
+    ALTER TABLE "_seo_v" ADD COLUMN IF NOT EXISTS "version_pages_news_more_title" varchar;
+    ALTER TABLE "_seo_v" ADD COLUMN IF NOT EXISTS "version_pages_news_more_description" varchar;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "seo" DROP COLUMN IF EXISTS "pages_news_more_title";
+    ALTER TABLE "seo" DROP COLUMN IF EXISTS "pages_news_more_description";
+    ALTER TABLE "_seo_v" DROP COLUMN IF EXISTS "version_pages_news_more_title";
+    ALTER TABLE "_seo_v" DROP COLUMN IF EXISTS "version_pages_news_more_description";
+  `)
+}

--- a/migrations/index.ts
+++ b/migrations/index.ts
@@ -34,6 +34,7 @@ import * as migration_20260423_010000_add_articles_last_modified_by from './2026
 import * as migration_20260423_020000_add_gemini_to_layout_skeleton from './20260423_020000_add_gemini_to_layout_skeleton';
 import * as migration_20260423_030000_add_header_animation_enabled from './20260423_030000_add_header_animation_enabled';
 import * as migration_20260423_040000_add_last_modified_by_to_layout_live_theme from './20260423_040000_add_last_modified_by_to_layout_live_theme';
+import * as migration_20260424_000000_add_news_more_seo_fields from './20260424_000000_add_news_more_seo_fields';
 
 export const migrations = [
   {
@@ -215,5 +216,10 @@ export const migrations = [
     up: migration_20260423_040000_add_last_modified_by_to_layout_live_theme.up,
     down: migration_20260423_040000_add_last_modified_by_to_layout_live_theme.down,
     name: '20260423_040000_add_last_modified_by_to_layout_live_theme',
+  },
+  {
+    up: migration_20260424_000000_add_news_more_seo_fields.up,
+    down: migration_20260424_000000_add_news_more_seo_fields.down,
+    name: '20260424_000000_add_news_more_seo_fields',
   },
 ];

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -1378,6 +1378,14 @@ export interface Seo {
      * Used for the /opinion/more-in-opinion page description.
      */
     opinionMoreDescription?: string | null;
+    /**
+     * Used for the /news/more-in-news page title.
+     */
+    newsMoreTitle?: string | null;
+    /**
+     * Used for the /news/more-in-news page description.
+     */
+    newsMoreDescription?: string | null;
   };
   /**
    * Descriptions used by the top-level section pages like /news, /sports, /features, and /opinion.
@@ -1519,6 +1527,8 @@ export interface SeoSelect<T extends boolean = true> {
         opinionEditorialsDescription?: T;
         opinionMoreTitle?: T;
         opinionMoreDescription?: T;
+        newsMoreTitle?: T;
+        newsMoreDescription?: T;
       };
   sections?:
     | T

--- a/scripts/run_deploy_sql_migrations.sh
+++ b/scripts/run_deploy_sql_migrations.sh
@@ -44,7 +44,8 @@ VALUES
   ('20260423_010000_add_articles_last_modified_by', 19, NOW(), NOW()),
   ('20260423_020000_add_gemini_to_layout_skeleton', 20, NOW(), NOW()),
   ('20260423_030000_add_header_animation_enabled', 21, NOW(), NOW()),
-  ('20260423_040000_add_last_modified_by_to_layout_live_theme', 22, NOW(), NOW())
+  ('20260423_040000_add_last_modified_by_to_layout_live_theme', 22, NOW(), NOW()),
+  ('20260424_000000_add_news_more_seo_fields', 23, NOW(), NOW())
 ON CONFLICT DO NOTHING;
 
 -- 20260317: Add opinion_type and image_caption columns
@@ -1181,4 +1182,10 @@ EXCEPTION WHEN duplicate_object THEN NULL; END $$;
 
 CREATE INDEX IF NOT EXISTS "theme_last_modified_by_idx" ON "theme" USING btree ("last_modified_by_id");
 CREATE INDEX IF NOT EXISTS "_theme_v_version_version_last_modified_by_idx" ON "_theme_v" USING btree ("version_last_modified_by_id");
+
+-- 20260424_000000: Add News "More in News" SEO fields to seo global
+ALTER TABLE "seo" ADD COLUMN IF NOT EXISTS "pages_news_more_title" varchar;
+ALTER TABLE "seo" ADD COLUMN IF NOT EXISTS "pages_news_more_description" varchar;
+ALTER TABLE "_seo_v" ADD COLUMN IF NOT EXISTS "version_pages_news_more_title" varchar;
+ALTER TABLE "_seo_v" ADD COLUMN IF NOT EXISTS "version_pages_news_more_description" varchar;
 SQL


### PR DESCRIPTION
Closes #101.

## Summary

- Creates `app/(frontend)/news/more-in-news/page.tsx`, mirroring the Opinion equivalent.
- Adds `components/News/NewsListPage.tsx` (parallel to `OpinionListPage.tsx`) for the list rendering. The existing Opinion component was hard-coded to "Back to Opinion" / `/opinion`, so it wasn't reusable as-is.
- Fixes the broken button in `components/News/NewsSectionPage.tsx:209`: the catch-all "Other News" group had `kickers: null`, which meant the fallback sent users back to `/news` (no-op). Now it points at `/news/more-in-news`.
- Adds two new SEO fields (`pages_news_more_title`, `pages_news_more_description`) on the `seo` global. Includes both migration paths per project convention:
  - TS migration: `migrations/20260424_000000_add_news_more_seo_fields.ts`
  - SQL: entry in `scripts/run_deploy_sql_migrations.sh` (batch 23 tracking row)
- Hand-edits `payload-types.ts` to reflect the schema change. A subsequent `pnpm generate:types` against a post-migration DB should produce identical output.

## Test plan

- [ ] Apply migrations, visit `/news/more-in-news` → list of published news articles renders with Header/Footer
- [ ] On the News section page, click the "More" button in the catch-all group → navigates to `/news/more-in-news`
- [ ] `pnpm generate:types` matches the hand edit in `payload-types.ts`
- [ ] Opinion's flow is unchanged