### PR TITLE
feat(analytics): number homepage slots and capture slot clicks

### DIFF
--- a/app/(frontend)/page.tsx
+++ b/app/(frontend)/page.tsx
@@ -689,6 +689,7 @@ export default async function Home() {
       <Header liveEntries={liveStripEntries} />
       <FrontPage
         topStories={topStories}
+        layoutName={layout.skeleton === 'taurus' ? 'taurus' : 'aries'}
         sections={{
           news: dropHero(newsArticles),
           features: dropHero(featuresArticles),

--- a/components/Dashboard/LayoutEditor/index.tsx
+++ b/components/Dashboard/LayoutEditor/index.tsx
@@ -23,6 +23,11 @@ import {
   arrayMove,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import {
+  getSlotNumber,
+  getCustomGridSlotLookup,
+  type HomepageLayoutName,
+} from '@/lib/homepageSlots';
 import './layout-editor.css';
 
 // ---------------------------------------------------------------------------
@@ -351,10 +356,11 @@ function ResizeHandle({ cellId, onResize }: {
 // Sub-cell inside a stack (droppable + draggable)
 // ---------------------------------------------------------------------------
 
-function SubCellComponent({ cell, article, onUpdateDirection, onClear, onDelete, canDelete }: {
+function SubCellComponent({ cell, article, onUpdateDirection, onClear, onDelete, canDelete, slotNumber }: {
   cell: GridCell; article: ArticleData | null;
   onUpdateDirection: (d: ImageDirection) => void; onClear: () => void;
   onDelete: () => void; canDelete: boolean;
+  slotNumber?: number | null;
 }) {
   const { isOver, setNodeRef: setDropRef } = useDroppable({
     id: `cell-${cell.id}`,
@@ -364,6 +370,9 @@ function SubCellComponent({ cell, article, onUpdateDirection, onClear, onDelete,
 
   return (
     <div ref={setDropRef} className={`le-subcell ${isOver ? 'le-cell-over' : ''} ${article ? 'le-subcell-filled' : ''}`}>
+      {typeof slotNumber === 'number' && (
+        <span className="le-slot-number" aria-label={`Slot ${slotNumber}`}>#{slotNumber}</span>
+      )}
       <div className="le-subcell-toolbar">
         {article && <DirectionPicker value={cell.direction} hasImage={hasImage} onChange={onUpdateDirection} />}
         <div className="le-cell-actions">
@@ -396,6 +405,7 @@ function SortableGridCell({
   onUpdateDirection, onClear, onDelete, canDelete,
   onSplit, onAddSubCell, onUpdateSubCell, onClearSubCell, onDeleteSubCell, onUnsplit,
   onResize,
+  slotNumberLookup,
 }: {
   cell: GridCell; article: ArticleData | null;
   articleMap: Map<number, ArticleData>;
@@ -406,8 +416,10 @@ function SortableGridCell({
   onClearSubCell: (subId: string) => void; onDeleteSubCell: (subId: string) => void;
   onUnsplit: () => void;
   onResize: (delta: number) => void;
+  slotNumberLookup?: Map<string, number>;
 }) {
   const stacked = isStackCell(cell);
+  const cellSlotNumber = !stacked ? slotNumberLookup?.get(cell.id) ?? null : null;
 
   const {
     attributes, listeners, setNodeRef: setSortRef,
@@ -437,6 +449,9 @@ function SortableGridCell({
       className={`le-cell ${!stacked && isOver ? 'le-cell-over' : ''} ${!stacked && article ? 'le-cell-filled' : ''} ${stacked ? 'le-cell-stacked' : ''}`}
       style={style}
     >
+      {typeof cellSlotNumber === 'number' && (
+        <span className="le-slot-number" aria-label={`Slot ${cellSlotNumber}`}>#{cellSlotNumber}</span>
+      )}
       {/* Cell toolbar */}
       <div className="le-cell-toolbar">
         {/* Drag handle for reordering columns */}
@@ -469,6 +484,7 @@ function SortableGridCell({
               onClear={() => onClearSubCell(sub.id)}
               onDelete={() => onDeleteSubCell(sub.id)}
               canDelete={cell.children!.length > 1}
+              slotNumber={slotNumberLookup?.get(sub.id) ?? null}
             />
           ))}
         </div>
@@ -522,6 +538,7 @@ function SortableGridRow({
   onDeleteRow, onAddCell, onUpdateCell, onDeleteCell, onClearCell,
   onSplitCell, onAddSubCell, onUpdateSubCell, onClearSubCell, onDeleteSubCell, onUnsplitCell,
   onResizeCell,
+  slotNumberLookup,
 }: {
   row: GridRow; rowIndex: number;
   articleMap: Map<number, ArticleData>;
@@ -534,6 +551,7 @@ function SortableGridRow({
   onDeleteSubCell: (cellId: string, subId: string) => void;
   onUnsplitCell: (cellId: string) => void;
   onResizeCell: (cellId: string, delta: number) => void;
+  slotNumberLookup?: Map<string, number>;
 }) {
   const {
     attributes, listeners, setNodeRef,
@@ -581,6 +599,7 @@ function SortableGridRow({
               onDeleteSubCell={(subId) => onDeleteSubCell(cell.id, subId)}
               onUnsplit={() => onUnsplitCell(cell.id)}
               onResize={(delta) => onResizeCell(cell.id, delta)}
+              slotNumberLookup={slotNumberLookup}
             />
           ))}
           {rowTotal < 12 && (
@@ -763,10 +782,11 @@ const getAriesBottomRequirement = (
 // Aries Slot Droppable
 // ---------------------------------------------------------------------------
 
-function AriesSlot({ slotId, label, article, isLead, isOver, setDropRef, onClear, emptyConstraint }: {
+function AriesSlot({ slotId, label, article, isLead, isOver, setDropRef, onClear, emptyConstraint, slotNumber }: {
   slotId: string; label: string; article: ArticleData | null; isLead: boolean;
   isOver: boolean; setDropRef: (node: HTMLElement | null) => void; onClear: () => void;
   emptyConstraint?: 'image' | 'text' | null;
+  slotNumber?: number | null;
 }) {
   const imageUrl = article ? getImageUrl(article) : null;
   const authorDate = article ? getAuthorDateString(article) : '';
@@ -776,6 +796,9 @@ function AriesSlot({ slotId, label, article, isLead, isOver, setDropRef, onClear
       ref={setDropRef}
       className={`le-aries-slot ${isLead ? 'le-aries-lead' : 'le-aries-hero'} ${isOver ? 'le-cell-over' : ''} ${article ? 'le-cell-filled' : ''}`}
     >
+      {typeof slotNumber === 'number' && (
+        <span className="le-slot-number" aria-label={`Slot ${slotNumber}`}>#{slotNumber}</span>
+      )}
       <div className="le-aries-slot-header">
         <span className="le-aries-slot-label">{label}</span>
         {article && <button className="le-cell-action-btn" onClick={onClear} title="Remove article">✕</button>}
@@ -851,14 +874,22 @@ function AriesSlot({ slotId, label, article, isLead, isOver, setDropRef, onClear
   );
 }
 
-function AriesDropSlot({ slotId, label, article, isLead, onClear, emptyConstraint }: {
+function AriesDropSlot({ slotId, label, article, isLead, onClear, emptyConstraint, numberingSkeleton }: {
   slotId: string; label: string; article: ArticleData | null; isLead: boolean; onClear: () => void;
   emptyConstraint?: 'image' | 'text' | null;
+  /**
+   * Which skeleton's slot-number scheme to use for the corner badge. This can
+   * differ from the DnD data `skeleton` key (which is always 'aries' here) —
+   * e.g. the gemini preset reuses AriesDropSlot for its slots but wants the
+   * gemini numbering.
+   */
+  numberingSkeleton?: Exclude<HomepageLayoutName, 'custom'> | null;
 }) {
   const { isOver, setNodeRef } = useDroppable({
     id: `aries-${slotId}`,
     data: { cellId: slotId, skeleton: 'aries' },
   });
+  const slotNumber = numberingSkeleton ? getSlotNumber(numberingSkeleton, slotId) : null;
   return (
     <AriesSlot
       slotId={slotId}
@@ -869,6 +900,7 @@ function AriesDropSlot({ slotId, label, article, isLead, onClear, emptyConstrain
       setDropRef={setNodeRef}
       onClear={onClear}
       emptyConstraint={emptyConstraint}
+      slotNumber={slotNumber}
     />
   );
 }
@@ -914,6 +946,7 @@ function AriesEditor({ data, articleMap, onClear, onToggleLeadImportant }: {
             article={data.lead !== null ? articleMap.get(data.lead) || null : null}
             isLead
             onClear={() => onClear('lead')}
+            numberingSkeleton="aries"
           />
           <label className="le-aries-important-toggle">
             <input
@@ -933,6 +966,7 @@ function AriesEditor({ data, articleMap, onClear, onToggleLeadImportant }: {
               article={article}
               isLead={false}
               onClear={() => onClear(slotId)}
+              numberingSkeleton="aries"
             />
           ))}
         </div>
@@ -951,6 +985,7 @@ function AriesEditor({ data, articleMap, onClear, onToggleLeadImportant }: {
               isLead={false}
               onClear={() => onClear('bottom-0')}
               emptyConstraint="text"
+              numberingSkeleton="aries"
             />
             <div className="le-aries-bottom-left-pair">
               {[1, 2].map((i) => (
@@ -962,6 +997,7 @@ function AriesEditor({ data, articleMap, onClear, onToggleLeadImportant }: {
                   isLead={false}
                   onClear={() => onClear(`bottom-${i}`)}
                   emptyConstraint="text"
+                  numberingSkeleton="aries"
                 />
               ))}
             </div>
@@ -972,6 +1008,7 @@ function AriesEditor({ data, articleMap, onClear, onToggleLeadImportant }: {
               isLead={false}
               onClear={() => onClear('bottom-3')}
               emptyConstraint="text"
+              numberingSkeleton="aries"
             />
           </div>
           <div className="le-aries-bottom-right">
@@ -982,6 +1019,7 @@ function AriesEditor({ data, articleMap, onClear, onToggleLeadImportant }: {
               isLead={false}
               onClear={() => onClear('bottom-4')}
               emptyConstraint="image"
+              numberingSkeleton="aries"
             />
             <div className="le-aries-bottom-right-pair">
               {[5, 6].map((i) => (
@@ -993,6 +1031,7 @@ function AriesEditor({ data, articleMap, onClear, onToggleLeadImportant }: {
                   isLead={false}
                   onClear={() => onClear(`bottom-${i}`)}
                   emptyConstraint="text"
+                  numberingSkeleton="aries"
                 />
               ))}
             </div>
@@ -1003,6 +1042,7 @@ function AriesEditor({ data, articleMap, onClear, onToggleLeadImportant }: {
               isLead={false}
               onClear={() => onClear('bottom-7')}
               emptyConstraint="text"
+              numberingSkeleton="aries"
             />
           </div>
         </div>
@@ -1281,6 +1321,13 @@ export function LayoutEditor() {
     : collectArticleIds(grid);
   const usedIds = new Set([...heroUsedIds, ...sectionPinnedIds]);
   const rowSortIds = grid.map((r) => `sortrow-${r.id}`);
+
+  /**
+   * Column-major slot-number lookup for the custom grid. Recomputed whenever
+   * grid structure changes. Used to show "#N" badges on each cell during
+   * drag-and-drop so editors can reference a slot by its stable number.
+   */
+  const customGridSlotLookup = getCustomGridSlotLookup(grid);
 
   // ---- Fetch ----
   useEffect(() => {
@@ -1986,6 +2033,7 @@ export function LayoutEditor() {
                           article={aries.left[i] !== null ? articleMap.get(aries.left[i]!) || null : null}
                           isLead={false}
                           onClear={() => { setAries((p) => { const next = { ...p, left: [...p.left] }; next.left[i] = null; return next; }); markDirty(); }}
+                          numberingSkeleton="gemini"
                         />
                         <SubdeckToggle slotId={`left-${i}`} />
                       </div>
@@ -1999,6 +2047,7 @@ export function LayoutEditor() {
                       article={aries.lead !== null ? articleMap.get(aries.lead) || null : null}
                       isLead
                       onClear={() => { setAries((p) => ({ ...p, lead: null })); markDirty(); }}
+                      numberingSkeleton="gemini"
                     />
                     <label className="le-aries-important-toggle">
                       <input
@@ -2037,6 +2086,7 @@ export function LayoutEditor() {
                           article={aries.right[i] !== null ? articleMap.get(aries.right[i]!) || null : null}
                           isLead={false}
                           onClear={() => { setAries((p) => { const next = { ...p, right: [...p.right] }; next.right[i] = null; return next; }); markDirty(); }}
+                          numberingSkeleton="gemini"
                         />
                         <SubdeckToggle slotId={`right-${i}`} />
                       </div>
@@ -2053,6 +2103,7 @@ export function LayoutEditor() {
                         article={aries.bottom[i] !== null ? articleMap.get(aries.bottom[i]!) || null : null}
                         isLead={false}
                         onClear={() => { setAries((p) => { const next = { ...p, bottom: [...p.bottom] }; next.bottom[i] = null; return next; }); markDirty(); }}
+                        numberingSkeleton="gemini"
                       />
                       <SubdeckToggle slotId={`bottom-${i}`} />
                     </div>
@@ -2070,16 +2121,16 @@ export function LayoutEditor() {
                 </div>
                 <div className="le-tau-grid">
                   <div className="le-tau-feature">
-                    <AriesDropSlot slotId="lead" label="Feature" article={aries.lead !== null ? articleMap.get(aries.lead) || null : null} isLead onClear={() => { setAries((p) => ({ ...p, lead: null })); markDirty(); }} />
+                    <AriesDropSlot slotId="lead" label="Feature" article={aries.lead !== null ? articleMap.get(aries.lead) || null : null} isLead onClear={() => { setAries((p) => ({ ...p, lead: null })); markDirty(); }} numberingSkeleton="taurus" />
                   </div>
                   <div className="le-tau-supporting">
                     {[0, 1, 2].map((i) => (
-                      <AriesDropSlot key={`left-${i}`} slotId={`left-${i}`} label={`Support ${i + 1}`} article={aries.left[i] !== null ? articleMap.get(aries.left[i]!) || null : null} isLead={false} onClear={() => { setAries((p) => { const next = { ...p, left: [...p.left] }; next.left[i] = null; return next; }); markDirty(); }} />
+                      <AriesDropSlot key={`left-${i}`} slotId={`left-${i}`} label={`Support ${i + 1}`} article={aries.left[i] !== null ? articleMap.get(aries.left[i]!) || null : null} isLead={false} onClear={() => { setAries((p) => { const next = { ...p, left: [...p.left] }; next.left[i] = null; return next; }); markDirty(); }} numberingSkeleton="taurus" />
                     ))}
                   </div>
                   <div className="le-tau-list">
                     {[0, 1, 2].map((i) => (
-                      <AriesDropSlot key={`right-${i}`} slotId={`right-${i}`} label={`List ${i + 1}`} article={aries.right[i] !== null ? articleMap.get(aries.right[i]!) || null : null} isLead={false} onClear={() => { setAries((p) => { const next = { ...p, right: [...p.right] }; next.right[i] = null; return next; }); markDirty(); }} />
+                      <AriesDropSlot key={`right-${i}`} slotId={`right-${i}`} label={`List ${i + 1}`} article={aries.right[i] !== null ? articleMap.get(aries.right[i]!) || null : null} isLead={false} onClear={() => { setAries((p) => { const next = { ...p, right: [...p.right] }; next.right[i] = null; return next; }); markDirty(); }} numberingSkeleton="taurus" />
                     ))}
                   </div>
                 </div>
@@ -2106,6 +2157,7 @@ export function LayoutEditor() {
                       onDeleteSubCell={(cellId, subId) => deleteSubCell(cellId, subId)}
                       onUnsplitCell={(cellId) => unsplitCell(cellId)}
                       onResizeCell={(cellId, delta) => resizeCell(cellId, delta)}
+                      slotNumberLookup={customGridSlotLookup}
                     />
                   ))}
                 </SortableContext>

--- a/components/Dashboard/LayoutEditor/layout-editor.css
+++ b/components/Dashboard/LayoutEditor/layout-editor.css
@@ -1150,6 +1150,7 @@
   padding: 4px 0 0;
 }
 .le-aries-slot {
+  position: relative;
   border: 1.5px dashed var(--theme-elevation-150, #252525);
   border-radius: 6px;
   background: var(--theme-bg, #0a0a0a);
@@ -1727,4 +1728,26 @@
   font-size: 11px;
   color: var(--theme-elevation-400, #666);
   font-style: italic;
+}
+
+/*
+ * Slot-number badge: rendered on every drop slot (aries/taurus/gemini/custom
+ * grid) so editors can reference a slot by its stable analytics "key" while
+ * dragging and dropping. Numbers come from lib/homepageSlots.ts.
+ */
+.le-slot-number {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 5;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+  padding: 3px 5px;
+  border-radius: 3px;
+  background: rgba(0, 0, 0, 0.75);
+  color: #fff;
+  pointer-events: none;
+  letter-spacing: 0.02em;
 }

--- a/components/FrontPage/GeminiHomepage.tsx
+++ b/components/FrontPage/GeminiHomepage.tsx
@@ -6,6 +6,7 @@ import { ImageCaption } from "./ImageCaption";
 import { ArticleCard } from "./ArticleCard";
 import type { Article } from "./types";
 import { getArticleUrl } from "@/utils/getArticleUrl";
+import { getSlotNumber } from "@/lib/homepageSlots";
 
 const getLeadDate = (article: Article): string | null => {
   if (article.date) return article.date;
@@ -183,14 +184,23 @@ export function GeminiHomepage({
             <aside className="order-2 md:order-none md:col-start-1 md:row-start-1 md:border-r md:border-rule md:pr-6 lg:pr-7">
               <div className="flex flex-col divide-y divide-rule">
                 {leftStack.map((article, i) => (
-                  <div key={article.id} className={i === 0 ? "pb-5" : "py-5 last:pb-0"}>
+                  <div
+                    key={article.id}
+                    className={i === 0 ? "pb-5" : "py-5 last:pb-0"}
+                    data-homepage-layout="gemini"
+                    data-homepage-slot={getSlotNumber("gemini", `left-${i}`) ?? undefined}
+                  >
                     <TextOnlyItem article={article} showSubdeck={showSubdeckLeft[i] !== false} />
                   </div>
                 ))}
               </div>
             </aside>
 
-            <div className="order-1 md:order-none md:col-start-2 md:row-start-1">
+            <div
+              className="order-1 md:order-none md:col-start-2 md:row-start-1"
+              data-homepage-layout="gemini"
+              data-homepage-slot={getSlotNumber("gemini", "lead") ?? undefined}
+            >
               <CenterLead
                 article={lead}
                 important={leadImportant}
@@ -202,7 +212,12 @@ export function GeminiHomepage({
             <aside className="order-4 md:order-none md:col-start-3 md:row-start-1 md:row-span-2 md:border-l md:border-rule md:pl-6 lg:pl-7">
               <div className="flex flex-col divide-y divide-rule">
                 {rightFeatures.map((article, i) => (
-                  <div key={article.id} className={i === 0 ? "pb-5" : "py-5 last:pb-0"}>
+                  <div
+                    key={article.id}
+                    className={i === 0 ? "pb-5" : "py-5 last:pb-0"}
+                    data-homepage-layout="gemini"
+                    data-homepage-slot={getSlotNumber("gemini", `right-${i}`) ?? undefined}
+                  >
                     <SideFeature article={article} showSubdeck={showSubdeckRight[i] !== false} />
                   </div>
                 ))}
@@ -216,6 +231,8 @@ export function GeminiHomepage({
                     <div
                       key={article.id}
                       className={`${i > 0 ? "pt-5 border-t border-rule sm:border-t-0 sm:pt-0 sm:pl-5" : "sm:pr-5"}`}
+                      data-homepage-layout="gemini"
+                      data-homepage-slot={getSlotNumber("gemini", `bottom-${i}`) ?? undefined}
                     >
                       <ArticleCard
                         article={article}

--- a/components/FrontPage/GridLayout.tsx
+++ b/components/FrontPage/GridLayout.tsx
@@ -5,6 +5,7 @@ import { Article } from "./types";
 import { Byline } from "./Byline";
 import { ImageCaption } from "./ImageCaption";
 import { getArticleUrl } from "@/utils/getArticleUrl";
+import { getCustomGridSlotLookup } from "@/lib/homepageSlots";
 
 type ImageDirection = "top" | "bottom" | "left" | "right" | "none";
 
@@ -191,25 +192,6 @@ const cellHasContent = (cell: GridCell, articleMap: Map<number, Article>): boole
   return false;
 };
 
-/** Collect all articles from the grid in order, for the mobile flat list */
-const collectGridArticles = (rows: GridRow[], articleMap: Map<number, Article>): Article[] => {
-  const result: Article[] = [];
-  for (const row of rows) {
-    for (const cell of row.cells) {
-      if (cell.children) {
-        for (const sub of cell.children) {
-          const a = sub.articleId ? articleMap.get(sub.articleId) : undefined;
-          if (a) result.push(a);
-        }
-      } else {
-        const a = cell.articleId ? articleMap.get(cell.articleId) : undefined;
-        if (a) result.push(a);
-      }
-    }
-  }
-  return result;
-};
-
 export function GridLayout({
   rows,
   articleMap,
@@ -219,17 +201,48 @@ export function GridLayout({
 }) {
   if (rows.length === 0) return null;
 
-  const mobileArticles = collectGridArticles(rows, articleMap);
+  // Stable column-major slot numbers (cellId -> slot number) used for
+  // homepage-click analytics. Matches the badge numbering shown in the admin
+  // layout editor.
+  const slotNumberLookup = getCustomGridSlotLookup(rows);
+
+  /**
+   * Collect mobile articles with their cell IDs so we can tag the stacked
+   * mobile list with the same slot numbers as the desktop grid. Equivalent to
+   * `collectGridArticles` but also preserves the originating cell id.
+   */
+  const mobileArticleEntries: Array<{ article: Article; cellId: string | null }> = [];
+  for (const row of rows) {
+    for (const cell of row.cells) {
+      if (cell.children) {
+        for (const sub of cell.children) {
+          const a = sub.articleId ? articleMap.get(sub.articleId) : undefined;
+          if (a) mobileArticleEntries.push({ article: a, cellId: sub.id });
+        }
+      } else {
+        const a = cell.articleId ? articleMap.get(cell.articleId) : undefined;
+        if (a) mobileArticleEntries.push({ article: a, cellId: cell.id });
+      }
+    }
+  }
 
   return (
     <div data-header-scope="primary">
       {/* Mobile: flat stacked list */}
       <div className="flex flex-col md:hidden">
-        {mobileArticles.map((article) => (
-          <div key={article.id} className="mt-5 pt-5 border-t border-black dark:border-white">
-            <MobileArticleCard article={article} />
-          </div>
-        ))}
+        {mobileArticleEntries.map(({ article, cellId }) => {
+          const slot = cellId ? slotNumberLookup.get(cellId) : undefined;
+          return (
+            <div
+              key={article.id}
+              className="mt-5 pt-5 border-t border-black dark:border-white"
+              data-homepage-layout="custom"
+              data-homepage-slot={slot ?? undefined}
+            >
+              <MobileArticleCard article={article} />
+            </div>
+          );
+        })}
       </div>
 
       {/* Desktop: 12-column grid */}
@@ -249,7 +262,9 @@ export function GridLayout({
               {row.cells.map((cell) => {
                 if (!cellHasContent(cell, articleMap)) return null;
 
-                // Stacked cell — render children vertically
+                // Stacked cell — render children vertically. Each sub-cell
+                // has its own slot number; we tag each sub-cell wrapper so
+                // clicks attribute to the correct slot.
                 if (cell.children && cell.children.length > 0) {
                   return (
                     <div
@@ -260,13 +275,19 @@ export function GridLayout({
                       {cell.children.map((sub) => {
                         const subArticle = sub.articleId ? articleMap.get(sub.articleId) : null;
                         if (!subArticle) return null;
+                        const subSlot = slotNumberLookup.get(sub.id);
                         return (
-                          <GridArticleCard
+                          <div
                             key={sub.id}
-                            article={subArticle}
-                            direction={sub.direction}
-                            span={cell.span}
-                          />
+                            data-homepage-layout="custom"
+                            data-homepage-slot={subSlot ?? undefined}
+                          >
+                            <GridArticleCard
+                              article={subArticle}
+                              direction={sub.direction}
+                              span={cell.span}
+                            />
+                          </div>
                         );
                       })}
                     </div>
@@ -276,12 +297,15 @@ export function GridLayout({
                 // Flat cell
                 const article = cell.articleId ? articleMap.get(cell.articleId) : null;
                 if (!article) return null;
+                const cellSlot = slotNumberLookup.get(cell.id);
 
                 return (
                   <div
                     key={cell.id}
                     style={{ gridColumn: `span ${cell.span}` }}
                     className="min-w-0"
+                    data-homepage-layout="custom"
+                    data-homepage-slot={cellSlot ?? undefined}
                   >
                     <GridArticleCard
                       article={article}

--- a/components/FrontPage/index.tsx
+++ b/components/FrontPage/index.tsx
@@ -4,6 +4,7 @@ import { LeadArticle } from "./LeadArticle";
 import { ArticleCard } from "./ArticleCard";
 import { ArticleListItem } from "./ArticleListItem";
 import { Article } from "./types";
+import { getSlotNumber, type HomepageLayoutName } from "@/lib/homepageSlots";
 
 interface FrontPageProps {
   topStories: {
@@ -23,6 +24,13 @@ interface FrontPageProps {
     sports: Article[];
     opinion: Article[];
   };
+  /**
+   * Identifies which top-level homepage skeleton is being rendered (for
+   * click-tracking analytics). The FrontPage component visually renders
+   * aries-style for both 'aries' and 'taurus'/legacy fallback; callers pass
+   * the actual skeleton name so analytics attribute correctly.
+   */
+  layoutName?: Exclude<HomepageLayoutName, "custom" | "gemini">;
 }
 
 interface HeroColumns {
@@ -271,6 +279,7 @@ export function SectionBlock({
 export default function FrontPage({
   topStories,
   sections,
+  layoutName = "aries",
 }: FrontPageProps) {
   const heroStories: HeroColumns = topStories.heroLeft && topStories.heroRight
     ? { left: topStories.heroLeft, right: topStories.heroRight }
@@ -280,22 +289,46 @@ export default function FrontPage({
   ).length;
   const leadIsCompact = heroImageCount >= 2;
 
+  /**
+   * Resolve the stable slot number for the current skeleton. Returns undefined
+   * when the slot key is unknown — we then skip emitting `data-homepage-slot`
+   * entirely rather than writing a misleading placeholder.
+   */
+  const slotAttr = (slotKey: string): number | undefined => {
+    const n = getSlotNumber(layoutName, slotKey);
+    return n ?? undefined;
+  };
+
   return (
     <div className="homepage-zodiac w-full bg-bg-main text-text-main transition-colors duration-300">
       <div className="mx-auto max-w-[1280px] px-4 pb-14 md:px-6 xl:px-[30px]">
         {/* Mobile: lead first, then a text article, then the rest */}
         <div className="pt-2 flex flex-col md:hidden" data-frontpage-top>
-          <LeadArticle article={topStories.lead} compact={false} hideKicker important={topStories.leadImportant} />
+          <div data-homepage-layout={layoutName} data-homepage-slot={slotAttr("lead")}>
+            <LeadArticle article={topStories.lead} compact={false} hideKicker important={topStories.leadImportant} />
+          </div>
           {(() => {
-            const heroArticles = [...heroStories.left, ...heroStories.right];
-            const bottomArticles = topStories.bottomRow || [];
-            const all = [...heroArticles, ...bottomArticles].filter((article): article is Article => Boolean(article));
-            const textIdx = all.findIndex((a) => !a.image);
+            // Keep a stable slot key for each article so mobile click tracking
+            // reports the same slot number as the desktop layout.
+            const taggedHero: Array<{ article: Article; slotKey: string }> = [
+              ...heroStories.left.map((article, i) => ({ article, slotKey: `left-${i}` })),
+              ...heroStories.right.map((article, i) => ({ article, slotKey: `right-${i}` })),
+            ];
+            const taggedBottom: Array<{ article: Article; slotKey: string }> = (topStories.bottomRow || [])
+              .map((article, i) => (article ? { article, slotKey: `bottom-${i}` } : null))
+              .filter((entry): entry is { article: Article; slotKey: string } => entry !== null);
+            const all = [...taggedHero, ...taggedBottom];
+            const textIdx = all.findIndex((e) => !e.article.image);
             const textFirst = textIdx >= 0 ? all[textIdx] : null;
             const rest = textFirst ? [...all.slice(0, textIdx), ...all.slice(textIdx + 1)] : all;
             const ordered = textFirst ? [textFirst, ...rest] : rest;
-            return ordered.map((article, i) => (
-              <div key={`${article.id}-${i}`} className="mt-5 pt-5 border-t border-black dark:border-white md:mt-10 md:pt-10 md:border-rule transition-colors">
+            return ordered.map(({ article, slotKey }, i) => (
+              <div
+                key={`${article.id}-${i}`}
+                className="mt-5 pt-5 border-t border-black dark:border-white md:mt-10 md:pt-10 md:border-rule transition-colors"
+                data-homepage-layout={layoutName}
+                data-homepage-slot={slotAttr(slotKey)}
+              >
                 <ArticleCard article={article} />
               </div>
             ));
@@ -309,33 +342,43 @@ export default function FrontPage({
         >
           {/* Left column: lead + bottom-left articles */}
           <div className="flex flex-col gap-5">
-            <LeadArticle article={topStories.lead} compact={leadIsCompact} important={topStories.leadImportant} />
+            <div data-homepage-layout={layoutName} data-homepage-slot={slotAttr("lead")}>
+              <LeadArticle article={topStories.lead} compact={leadIsCompact} important={topStories.leadImportant} />
+            </div>
             {topStories.bottomRow?.[0] && (
-              <ArticleCard
-                article={topStories.bottomRow[0]}
-                showImage={false}
-                contained
-                showKicker
-              />
+              <div data-homepage-layout={layoutName} data-homepage-slot={slotAttr("bottom-0")}>
+                <ArticleCard
+                  article={topStories.bottomRow[0]}
+                  showImage={false}
+                  contained
+                  showKicker
+                />
+              </div>
             )}
             {(topStories.bottomRow?.[1] || topStories.bottomRow?.[2]) && (
               <div className="grid grid-cols-[1fr_1px_1fr] gap-x-5 items-start">
                 {topStories.bottomRow[1] && (
-                  <ArticleCard article={topStories.bottomRow[1]} showImage={false} contained showKicker />
+                  <div data-homepage-layout={layoutName} data-homepage-slot={slotAttr("bottom-1")}>
+                    <ArticleCard article={topStories.bottomRow[1]} showImage={false} contained showKicker />
+                  </div>
                 )}
                 <div className="self-stretch bg-rule" />
                 {topStories.bottomRow[2] && (
-                  <ArticleCard article={topStories.bottomRow[2]} showImage={false} contained showKicker />
+                  <div data-homepage-layout={layoutName} data-homepage-slot={slotAttr("bottom-2")}>
+                    <ArticleCard article={topStories.bottomRow[2]} showImage={false} contained showKicker />
+                  </div>
                 )}
               </div>
             )}
             {topStories.bottomRow?.[3] && (
-              <ArticleCard
-                article={topStories.bottomRow[3]}
-                showImage={false}
-                contained
-                showKicker
-              />
+              <div data-homepage-layout={layoutName} data-homepage-slot={slotAttr("bottom-3")}>
+                <ArticleCard
+                  article={topStories.bottomRow[3]}
+                  showImage={false}
+                  contained
+                  showKicker
+                />
+              </div>
             )}
           </div>
           {/* Column divider */}
@@ -345,7 +388,12 @@ export default function FrontPage({
             <div className="grid grid-cols-[1fr_1px_1fr] gap-x-5">
               <div className="flex flex-col">
                 {heroStories.left.map((article, i) => (
-                  <div key={article.id} className={i > 0 ? "pt-3" : "pb-3"}>
+                  <div
+                    key={article.id}
+                    className={i > 0 ? "pt-3" : "pb-3"}
+                    data-homepage-layout={layoutName}
+                    data-homepage-slot={slotAttr(`left-${i}`)}
+                  >
                     <ArticleCard article={article} showKicker />
                   </div>
                 ))}
@@ -353,40 +401,53 @@ export default function FrontPage({
               <div className="self-stretch bg-rule" />
               <div className="flex flex-col">
                 {heroStories.right.map((article, i) => (
-                  <div key={article.id} className={i > 0 ? "pt-3" : "pb-3"}>
+                  <div
+                    key={article.id}
+                    className={i > 0 ? "pt-3" : "pb-3"}
+                    data-homepage-layout={layoutName}
+                    data-homepage-slot={slotAttr(`right-${i}`)}
+                  >
                     <ArticleCard article={article} showKicker />
                   </div>
                 ))}
               </div>
             </div>
             {topStories.bottomRow?.[4] && (
-              <ArticleCard
-                article={topStories.bottomRow[4]}
-                contained
-                showKicker
-                imageRight
-                imageAspectClassName="aspect-[4/3]"
-              />
+              <div data-homepage-layout={layoutName} data-homepage-slot={slotAttr("bottom-4")}>
+                <ArticleCard
+                  article={topStories.bottomRow[4]}
+                  contained
+                  showKicker
+                  imageRight
+                  imageAspectClassName="aspect-[4/3]"
+                />
+              </div>
             )}
             {(topStories.bottomRow?.[5] || topStories.bottomRow?.[6]) && (
               <div className="grid grid-cols-[1fr_1px_1fr] gap-x-5 items-start">
                 {topStories.bottomRow[5] && (
-                  <ArticleCard article={topStories.bottomRow[5]} showImage={false} contained showKicker />
+                  <div data-homepage-layout={layoutName} data-homepage-slot={slotAttr("bottom-5")}>
+                    <ArticleCard article={topStories.bottomRow[5]} showImage={false} contained showKicker />
+                  </div>
                 )}
                 <div className="self-stretch bg-rule" />
                 {topStories.bottomRow[6] && (
-                  <ArticleCard article={topStories.bottomRow[6]} showImage={false} contained showKicker />
+                  <div data-homepage-layout={layoutName} data-homepage-slot={slotAttr("bottom-6")}>
+                    <ArticleCard article={topStories.bottomRow[6]} showImage={false} contained showKicker />
+                  </div>
                 )}
               </div>
             )}
             {topStories.bottomRow?.[7] && (
-              <ArticleCard
-                article={topStories.bottomRow[7]}
-                showImage={false}
-                showExcerpt={false}
-                contained
-                showKicker
-              />
+              <div data-homepage-layout={layoutName} data-homepage-slot={slotAttr("bottom-7")}>
+                <ArticleCard
+                  article={topStories.bottomRow[7]}
+                  showImage={false}
+                  showExcerpt={false}
+                  contained
+                  showKicker
+                />
+              </div>
             )}
           </div>
         </div>

--- a/components/analytics/SiteAnalytics.tsx
+++ b/components/analytics/SiteAnalytics.tsx
@@ -18,6 +18,21 @@ const ACTIVE_WINDOW_MS = 30_000;
 const TICK_SECONDS = 5;
 const READ_COMPLETION_THRESHOLD = 85;
 const SITE_ACTIVE_SECONDS_STORAGE_KEY = "posthog_site_active_seconds";
+/**
+ * Cap the session-scoped homepage-slot click log so we don't bloat
+ * `page_session_summary` payloads on runaway sessions. Visitors almost never
+ * exceed a handful of slot clicks; 25 is a safe upper bound.
+ */
+const MAX_HOMEPAGE_SLOT_CLICKS_PER_SESSION = 25;
+
+type HomepageSlotClick = {
+  /** Skeleton name from data-homepage-layout, e.g. "aries" / "custom". */
+  layout: string;
+  /** Stable column-major slot number from data-homepage-slot. */
+  slot: number;
+  /** Seconds since session start when the click happened. */
+  at_seconds: number;
+};
 
 function getDocumentScrollPercentage() {
   const scrollableHeight = document.documentElement.scrollHeight - window.innerHeight;
@@ -197,6 +212,13 @@ export default function SiteAnalytics({ user }: SiteAnalyticsProps) {
   const themeSecondsRef = useRef({ light: 0, dark: 0 });
   const currentThemeRef = useRef(isDarkMode ? "dark" : "light");
 
+  // Homepage slot-click history for the current session. Issue #45 — an array
+  // of {layout, slot, at_seconds} entries describing which homepage-layout
+  // slots the user clicked. Flushed into `page_session_summary` so we can
+  // filter sessions by homepage behavior.
+  const homepageSlotClicksRef = useRef<HomepageSlotClick[]>([]);
+  const sessionStartTimeRef = useRef<number>(Date.now());
+
   useEffect(() => {
     const newTheme = isDarkMode ? "dark" : "light";
     themeRef.current = newTheme;
@@ -374,11 +396,50 @@ export default function SiteAnalytics({ user }: SiteAnalyticsProps) {
       const destinationPath = normalizePath(destination.pathname);
       const clickContext = getClickContext(anchor, currentPath);
       const linkText = getLinkLabel(anchor);
+
+      // Homepage slot enrichment: when the click originated inside a slot
+      // tagged by the homepage renderers (see lib/homepageSlots.ts +
+      // components/FrontPage/*), capture the layout name + stable slot number
+      // so downstream analytics can attribute clicks to specific homepage
+      // positions. Only populated on `/` since those data-attributes are only
+      // emitted there.
+      let homepageLayout: string | undefined;
+      let homepageSlot: number | undefined;
+      const slotElement = anchor.closest("[data-homepage-slot]");
+      if (slotElement instanceof HTMLElement) {
+        const rawSlot = slotElement.dataset.homepageSlot;
+        const rawLayout =
+          slotElement.dataset.homepageLayout ||
+          (slotElement.closest("[data-homepage-layout]") as HTMLElement | null)?.dataset.homepageLayout;
+        const parsedSlot = rawSlot ? Number.parseInt(rawSlot, 10) : NaN;
+        if (Number.isFinite(parsedSlot) && rawLayout) {
+          homepageLayout = rawLayout;
+          homepageSlot = parsedSlot;
+          // Append to the session log (capped).
+          if (homepageSlotClicksRef.current.length < MAX_HOMEPAGE_SLOT_CLICKS_PER_SESSION) {
+            homepageSlotClicksRef.current.push({
+              layout: rawLayout,
+              slot: parsedSlot,
+              at_seconds: Math.max(
+                0,
+                Math.round((Date.now() - sessionStartTimeRef.current) / 1000),
+              ),
+            });
+          }
+        }
+      }
+
+      const slotProperties =
+        homepageLayout && typeof homepageSlot === "number"
+          ? { homepage_layout: homepageLayout, homepage_slot: homepageSlot }
+          : {};
+
       const baseProperties = {
         ...getPageEventProperties(currentPath),
         theme: themeRef.current,
         click_context: clickContext,
         link_text: linkText,
+        ...slotProperties,
       };
 
       const isExternal = destination.origin !== window.location.origin;
@@ -437,6 +498,19 @@ export default function SiteAnalytics({ user }: SiteAnalyticsProps) {
         ? Math.round(meta.wordCount / (pageActiveSecondsRef.current / 60))
         : undefined;
 
+      // Homepage slot summary — only attached when at least one slot click
+      // happened this session. We copy the array so the ref can continue to
+      // mutate without affecting the emitted event.
+      const slotClicks = homepageSlotClicksRef.current;
+      const lastSlotClick = slotClicks.length > 0 ? slotClicks[slotClicks.length - 1] : null;
+      const slotSummaryProps = slotClicks.length > 0
+        ? {
+            homepage_slot_clicks: slotClicks.slice(),
+            homepage_last_layout: lastSlotClick?.layout,
+            homepage_last_slot: lastSlotClick?.slot,
+          }
+        : {};
+
       posthog.capture("page_session_summary", {
         ...getPageEventProperties(currentPath),
         theme: themeRef.current,
@@ -454,6 +528,10 @@ export default function SiteAnalytics({ user }: SiteAnalyticsProps) {
         total_chars_copied: totalCharsCopiedRef.current,
         seconds_spent_in_light_mode: finalThemeSeconds.light,
         seconds_spent_in_dark_mode: finalThemeSeconds.dark,
+
+        // Homepage slot interactions (Issue #45) — only present when the
+        // user clicked at least one tagged homepage slot this session.
+        ...slotSummaryProps,
 
         // Article-specific fields (null/absent on non-article pages)
         ...(isArticle ? {

--- a/lib/homepageSlots.ts
+++ b/lib/homepageSlots.ts
@@ -1,0 +1,223 @@
+/**
+ * Stable homepage slot numbering.
+ *
+ * Each slot in a homepage skeleton gets a stable integer "key" used both for
+ * the admin editor (shown as a corner badge while dragging) and for
+ * click-event analytics on the live site.
+ *
+ * Numbering rule: column-major visual reading order — go down the leftmost
+ * visual column top-to-bottom, then the next column. Where a skeleton has
+ * ambiguous internal structure, we pick a stable order matching the editor's
+ * natural layout so editors can reason about slot numbers without surprise.
+ *
+ * The numbers for a given (skeleton, slotKey) MUST be stable across page
+ * loads, users, and environments. Downstream analytics treat them as opaque
+ * identifiers — renumbering invalidates historical data.
+ */
+export type HomepageLayoutName = 'custom' | 'aries' | 'taurus' | 'gemini';
+
+/**
+ * Aries (stored as AriesData: lead / left[] / right[] / bottom[]).
+ *
+ * Visual desktop layout from components/FrontPage/index.tsx:
+ *
+ *   ┌──────────────┐┌──────────────┐
+ *   │ lead         ││ left-0│right-0│  (hero grid = heroLeft col + heroRight col)
+ *   │              ││ left-1│right-1│
+ *   │              ││ left-2│right-2│
+ *   ├──────────────┤├──────────────┤
+ *   │ bottom-0     ││ bottom-4     │
+ *   │ btm-1│btm-2  ││ btm-5│btm-6  │
+ *   │ bottom-3     ││ bottom-7     │
+ *   └──────────────┘└──────────────┘
+ *
+ * Column-major reading order (column 1 = left band, column 2 = hero-left band,
+ * column 3 = hero-right band — the two hero sub-columns are treated as
+ * separate visual columns since they render as side-by-side stacks):
+ */
+const ARIES_SLOTS: Record<string, number> = {
+  // Column 1 — lead + left bottom stack
+  lead: 1,
+  'bottom-0': 2,
+  'bottom-1': 3,
+  'bottom-2': 4,
+  'bottom-3': 5,
+  // Column 2 — heroLeft stack
+  'left-0': 6,
+  'left-1': 7,
+  'left-2': 8,
+  // Column 3 — heroRight stack + right bottom stack
+  'right-0': 9,
+  'right-1': 10,
+  'right-2': 11,
+  'bottom-4': 12,
+  'bottom-5': 13,
+  'bottom-6': 14,
+  'bottom-7': 15,
+};
+
+/**
+ * Taurus (feature-with-list skeleton; used mostly for section blocks but also
+ * available as the top skeleton). Stored on the aries-shaped record:
+ * lead = feature story, left[0..2] = supporting, right[0..2] = list rail.
+ *
+ *   ┌──────────────┬──────────┐
+ *   │ lead         │ right-0  │
+ *   │ (feature)    │ right-1  │
+ *   │              │ right-2  │
+ *   ├──────────────┤          │
+ *   │ left-0       │          │
+ *   │ left-1       │          │
+ *   │ left-2       │          │
+ *   └──────────────┴──────────┘
+ *
+ * Column-major: col 1 = lead + supporting, col 2 = list rail.
+ */
+const TAURUS_SLOTS: Record<string, number> = {
+  lead: 1,
+  'left-0': 2,
+  'left-1': 3,
+  'left-2': 4,
+  'right-0': 5,
+  'right-1': 6,
+  'right-2': 7,
+};
+
+/**
+ * Gemini (from components/FrontPage/GeminiHomepage.tsx). Three columns plus a
+ * two-card bottom row that spans under the left + center columns; the right
+ * column feature stack runs full-height.
+ *
+ *   ┌────────┬────────┬────────┐
+ *   │ left-0 │ lead   │ right-0│
+ *   │ left-1 │        │ right-1│
+ *   │ left-2 │        │ right-2│
+ *   │ left-3 │        │ right-3│
+ *   │ left-4 │        │ right-4│
+ *   │ left-5 │        │        │
+ *   ├────────┼────────┤        │
+ *   │ bottom-0        │        │
+ *   │ │bottom-1       │        │
+ *   └────────┴────────┴────────┘
+ *
+ * Column-major: col 1 = left stack + bottom-0, col 2 = lead + bottom-1,
+ * col 3 = right feature stack.
+ */
+const GEMINI_SLOTS: Record<string, number> = {
+  // Column 1
+  'left-0': 1,
+  'left-1': 2,
+  'left-2': 3,
+  'left-3': 4,
+  'left-4': 5,
+  'left-5': 6,
+  'bottom-0': 7,
+  // Column 2
+  lead: 8,
+  'bottom-1': 9,
+  // Column 3
+  'right-0': 10,
+  'right-1': 11,
+  'right-2': 12,
+  'right-3': 13,
+  'right-4': 14,
+};
+
+const NAMED_SKELETON_SLOTS: Record<Exclude<HomepageLayoutName, 'custom'>, Record<string, number>> = {
+  aries: ARIES_SLOTS,
+  taurus: TAURUS_SLOTS,
+  gemini: GEMINI_SLOTS,
+};
+
+export type CustomGridCell = {
+  id: string;
+  span: number;
+  articleId?: number | null;
+  children?: CustomGridCell[];
+};
+
+export type CustomGridRow = {
+  id: string;
+  cells: CustomGridCell[];
+};
+
+/**
+ * Enumerate all slot positions in a custom grid, column-major.
+ *
+ * Algorithm: walk every leaf cell (flat cells + stack sub-cells), compute its
+ * (columnStart, rowIndex, stackIndex) triple, and sort by
+ * (columnStart ASC, rowIndex ASC, stackIndex ASC). This gives column-major
+ * "down then right" reading order.
+ *
+ * Note: stack sub-cells share their parent cell's columnStart, so they end up
+ * numbered consecutively within the same visual column (top-to-bottom),
+ * which matches user expectation.
+ */
+function enumerateCustomGridSlots(rows: CustomGridRow[]): Array<{ key: string; number: number }> {
+  type LeafRef = { key: string; colStart: number; rowIdx: number; stackIdx: number };
+  const leaves: LeafRef[] = [];
+
+  rows.forEach((row, rowIdx) => {
+    let colCursor = 0;
+    for (const cell of row.cells) {
+      const colStart = colCursor;
+      if (cell.children && cell.children.length > 0) {
+        cell.children.forEach((sub, stackIdx) => {
+          leaves.push({ key: sub.id, colStart, rowIdx, stackIdx });
+        });
+      } else {
+        leaves.push({ key: cell.id, colStart, rowIdx, stackIdx: 0 });
+      }
+      colCursor += cell.span;
+    }
+  });
+
+  leaves.sort((a, b) => {
+    if (a.colStart !== b.colStart) return a.colStart - b.colStart;
+    if (a.rowIdx !== b.rowIdx) return a.rowIdx - b.rowIdx;
+    return a.stackIdx - b.stackIdx;
+  });
+
+  return leaves.map((leaf, i) => ({ key: leaf.key, number: i + 1 }));
+}
+
+/**
+ * Get the slot number for a single slot on a named-skeleton layout.
+ *
+ * Returns null if the slot key is not recognized for that skeleton. Call
+ * `getAllSlotsForSkeleton` or `getCustomGridSlotLookup` for custom-grid
+ * numbering since those IDs are derived from the live grid.
+ */
+export function getSlotNumber(
+  layout: Exclude<HomepageLayoutName, 'custom'>,
+  slotKey: string,
+): number | null {
+  const map = NAMED_SKELETON_SLOTS[layout];
+  return map[slotKey] ?? null;
+}
+
+/**
+ * Return the full ordered slot set for a named skeleton. Used by the admin
+ * editor to render number badges on each slot card.
+ */
+export function getAllSlotsForSkeleton(
+  layout: Exclude<HomepageLayoutName, 'custom'>,
+): Array<{ key: string; number: number }> {
+  const map = NAMED_SKELETON_SLOTS[layout];
+  return Object.entries(map)
+    .map(([key, number]) => ({ key, number }))
+    .sort((a, b) => a.number - b.number);
+}
+
+/**
+ * Build a lookup `cellId -> slotNumber` for a custom grid. The caller feeds
+ * this map when rendering — each cell's `id` resolves to its column-major
+ * position.
+ */
+export function getCustomGridSlotLookup(rows: CustomGridRow[]): Map<string, number> {
+  const lookup = new Map<string, number>();
+  for (const { key, number } of enumerateCustomGridSlots(rows)) {
+    lookup.set(key, number);
+  }
+  return lookup;
+}


### PR DESCRIPTION
Closes #45.

## Summary

- Assigns a stable integer "key" to every slot in each homepage skeleton (column-major, top-to-bottom then left-to-right) via `lib/homepageSlots.ts`.
- Renders the slot number as a small badge in the admin `LayoutEditor` while editors are dragging/dropping, so they can match a slot in the editor to a PostHog event.
- Tags each rendered homepage slot wrapper with `data-homepage-layout` and `data-homepage-slot`.
- Extends the existing `SiteAnalytics` click delegate: when a clicked anchor is inside a tagged slot, `homepage_layout` (string) and `homepage_slot` (integer) are attached to `article_clicked`, `outbound_link_clicked`, and `staff_profile_clicked`.
- Adds session-scoped summary fields on `page_session_summary` (only when at least one slot click happened):
  - `homepage_slot_clicks: Array<{ layout, slot, at_seconds }>` — capped at 25 entries
  - `homepage_last_layout: string`
  - `homepage_last_slot: number`

### Slot numbering

- **Aries** — column-major across its 3-column grid: `lead=1`, `bottom-0..3=2..5` (left col); `left-0..2=6..8`; `right-0..2=9..11`, `bottom-4..7=12..15` (right col)
- **Taurus** — `lead=1`, `left-0..2=2..4`, `right-0..2=5..7`
- **Gemini** — `left-0..5=1..6`, `bottom-0=7` (col 1); `lead=8`, `bottom-1=9` (col 2); `right-0..4=10..14` (col 3)
- **Custom** — every leaf cell/sub-cell sorted by `(columnStart, rowIndex, stackIndex)` and numbered 1..N

## Privacy-policy impact

No change required. The existing disclosure already covers this ("we collect things like… which links you click", "our analytics are session-only"). Slot numbers describe the *layout position* of a clicked link — structural/editorial metadata, not user identity. No IP, no persistent identifiers, no cross-session storage added. The session array is bounded and discarded on tab close with the rest of the session data.

## Test plan

- [ ] Open Homepage Layout editor — every slot card shows a numeric badge
- [ ] Numbers remain visible while dragging a slot
- [ ] On the live homepage, inspect any slot wrapper — has `data-homepage-layout` and `data-homepage-slot` attributes
- [ ] Click an article on the homepage → PostHog `article_clicked` event includes the two new fields
- [ ] Close tab and confirm the `page_session_summary` event carries `homepage_slot_clicks` when at least one click occurred, and omits it otherwise
- [ ] No new npm deps; no DB migrations