### PR TITLE
fix(footer): reveal scroll line when logo is fully visible

### DIFF
--- a/components/FooterClient.tsx
+++ b/components/FooterClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useTheme } from "@/components/ThemeProvider";
@@ -10,24 +10,29 @@ export default function FooterClient({ volume, edition }: { volume?: number | nu
   const { isDarkMode, logoSrcs } = useTheme();
   const logoSrc = isDarkMode ? logoSrcs.mobileDark : logoSrcs.mobileLight;
   const [lineVisible, setLineVisible] = useState(false);
+  const logoRef = useRef<HTMLAnchorElement | null>(null);
 
   useEffect(() => {
-    const checkIfAtBottom = () => {
-      const viewportBottom = window.scrollY + window.innerHeight;
-      const pageBottom = document.documentElement.scrollHeight;
+    const target = logoRef.current;
+    if (!target) return;
 
-      if (viewportBottom >= pageBottom - 2) {
-        setLineVisible(true);
-      }
-    };
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting && entry.intersectionRatio >= 1) {
+            setLineVisible(true);
+            observer.disconnect();
+            break;
+          }
+        }
+      },
+      { threshold: 1 },
+    );
 
-    checkIfAtBottom();
-    window.addEventListener("scroll", checkIfAtBottom, { passive: true });
-    window.addEventListener("resize", checkIfAtBottom);
+    observer.observe(target);
 
     return () => {
-      window.removeEventListener("scroll", checkIfAtBottom);
-      window.removeEventListener("resize", checkIfAtBottom);
+      observer.disconnect();
     };
   }, []);
 
@@ -44,7 +49,7 @@ export default function FooterClient({ volume, edition }: { volume?: number | nu
       </div>
       <div className="safe-area-mobile-page-x mx-auto max-w-[1280px] px-6 pt-6 pb-8 md:px-6 xl:px-[30px]">
         <div className="flex flex-col items-center gap-6">
-          <Link href="/" className="relative block h-[52px] w-[320px]">
+          <Link ref={logoRef} href="/" className="relative block h-[52px] w-[320px]">
             <Image
               src={logoSrc}
               alt="The Polytechnic"


### PR DESCRIPTION
Closes #105.

## Summary

Replaces the scroll/resize listener in `components/FooterClient.tsx` with an `IntersectionObserver` at `threshold: 1.0` targeting the footer logo `<Link>`. When the logo is fully in view the observer flips `lineVisible` to true and disconnects — sticky-once-shown behavior preserved, scaleX animation unchanged, no scroll handlers installed.

## Test plan

- [ ] On a long page (homepage), scroll until the logo is fully in view → line sweeps in
- [ ] Scroll back up out of view and back down → line stays in its shown state (no flicker)
- [ ] On a short page where the logo is already in view at load → line is shown immediately