### PR TITLE
feat(mobile): drive Android system bars from in-app theme toggle

### DIFF
--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -151,6 +151,16 @@ export default function ThemeProvider({
       "content",
       isStandalonePwa ? "black-translucent" : isDarkMode ? "black" : "default",
     );
+
+    // Android app bridge: drive the native status + nav bars from the in-app
+    // theme so they follow the site toggle rather than the phone's ui mode.
+    // window.PolyTheme is only present when loaded inside the Capacitor shell.
+    try {
+      const polyTheme = (window as unknown as { PolyTheme?: { setDark?: (dark: boolean) => void } }).PolyTheme;
+      polyTheme?.setDark?.(isDarkMode);
+    } catch {
+      /* bridge unavailable (web browser or iOS) */
+    }
   }, [isDarkMode, isStandalonePwa]);
 
   const toggleDarkMode = () => {

--- a/mobile/android/app/src/main/java/edu/rpi/poly/MainActivity.java
+++ b/mobile/android/app/src/main/java/edu/rpi/poly/MainActivity.java
@@ -3,6 +3,8 @@ package edu.rpi.poly;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.Window;
+import android.webkit.JavascriptInterface;
+import android.webkit.WebView;
 
 import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
@@ -14,37 +16,64 @@ public class MainActivity extends BridgeActivity {
     private static final int LIGHT_BG = 0xFFFFFFFF;
     private static final int DARK_BG = 0xFF0A0A0A;
 
+    // null = no override; mirror the phone's ui mode.
+    // true / false = site-controlled override (via window.PolyTheme.setDark).
+    private Boolean siteThemeOverride = null;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        applySystemBars();
+
+        WebView webView = getBridge() != null ? getBridge().getWebView() : null;
+        if (webView != null) {
+            // Exposes window.PolyTheme.setDark(boolean) to poly.rpi.edu so the
+            // in-app theme toggle can drive the Android status + navigation bars.
+            webView.addJavascriptInterface(new ThemeBridge(), "PolyTheme");
+        }
+
+        applyBars(isSystemDark());
         PushRegistration.start(this);
     }
 
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
-        applySystemBars();
+        // If the site hasn't reported a theme yet, follow the system. Once the
+        // site has spoken we keep honoring its choice until it changes.
+        applyBars(siteThemeOverride != null ? siteThemeOverride : isSystemDark());
     }
 
-    // Theme.SplashScreen (the activity's launch theme) ignores our themed
-    // statusBarColor/navigationBarColor attributes, which is why the bars
-    // stayed black regardless of light/dark before. Pinning them here at
-    // runtime forces the bars to the current uiMode's colors.
-    private void applySystemBars() {
-        final Window window = getWindow();
-        final boolean night =
-                (getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK)
-                        == Configuration.UI_MODE_NIGHT_YES;
-        final int color = night ? DARK_BG : LIGHT_BG;
+    private boolean isSystemDark() {
+        return (getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK)
+                == Configuration.UI_MODE_NIGHT_YES;
+    }
 
-        WindowCompat.setDecorFitsSystemWindows(window, true);
-        window.setStatusBarColor(color);
-        window.setNavigationBarColor(color);
+    private void applyBars(final boolean dark) {
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                final Window window = getWindow();
+                final int color = dark ? DARK_BG : LIGHT_BG;
 
-        WindowInsetsControllerCompat controller =
-                new WindowInsetsControllerCompat(window, window.getDecorView());
-        controller.setAppearanceLightStatusBars(!night);
-        controller.setAppearanceLightNavigationBars(!night);
+                WindowCompat.setDecorFitsSystemWindows(window, true);
+                window.setStatusBarColor(color);
+                window.setNavigationBarColor(color);
+
+                WindowInsetsControllerCompat controller =
+                        new WindowInsetsControllerCompat(window, window.getDecorView());
+                controller.setAppearanceLightStatusBars(!dark);
+                controller.setAppearanceLightNavigationBars(!dark);
+            }
+        });
+    }
+
+    // JavaScript interface exposed to the WebView as `window.PolyTheme`.
+    // Only setDark(boolean) is exposed; no sensitive capabilities are reachable.
+    private class ThemeBridge {
+        @JavascriptInterface
+        public void setDark(boolean dark) {
+            siteThemeOverride = dark;
+            applyBars(dark);
+        }
     }
 }


### PR DESCRIPTION
## Summary
Makes the Android app's status bar + navigation bar follow the site's in-app theme toggle instead of the phone's system uiMode.

- `MainActivity.java` — exposes `window.PolyTheme.setDark(boolean)` via `addJavascriptInterface`. Surface is a single boolean method; nothing sensitive is reachable.
- `ThemeProvider.tsx` — calls the bridge in the existing `isDarkMode` effect. No-op on browser / iOS.
- System-theme follow stays as the default and as the fallback for config changes received before the site has spoken.

## Why not the Capawesome EdgeToEdge plugin?
Considered. It's the modern answer (handles Android 15+ edge-to-edge correctly) but requires Capacitor 7+; we're on 6. Staying on Capacitor 6 for now avoids a larger upgrade; the native window calls we use still work through Android 15 at targetSdk=34.

## Test plan
- [ ] Install v0.0.3-android (auto-built after merge)
- [ ] Phone in light mode, open app → bars white, site white. Tap theme toggle → site + bars flip to dark. Tap again → back to light.
- [ ] Phone in dark mode, open app → bars dark. Toggle site to light → bars flip white (this is the bug we're fixing).
- [ ] Web browser → nothing breaks; no console errors about PolyTheme.