### PR TITLE
fix(frontend): mobile scroll header — match articles, fix tablet overlap, persist theme

### DIFF
--- a/components/MobileScrollHeader.tsx
+++ b/components/MobileScrollHeader.tsx
@@ -1,24 +1,39 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import Link from 'next/link';
-import { Menu, Search } from 'lucide-react';
-import { MobileMenuDrawer } from '@/components/MobileMenuDrawer';
+import { Moon, Search, Sun } from 'lucide-react';
 import SearchOverlay from '@/components/SearchOverlay';
 import { useTheme } from '@/components/ThemeProvider';
 
 const SHOW_THRESHOLD = 220;
 
+function triggerThemeTransition(x: number, y: number, apply: () => void) {
+  const root = document.documentElement;
+  const maxR = Math.hypot(
+    Math.max(x, window.innerWidth - x),
+    Math.max(y, window.innerHeight - y),
+  );
+  root.style.setProperty('--theme-x', `${x}px`);
+  root.style.setProperty('--theme-y', `${y}px`);
+  root.style.setProperty('--theme-r', `${maxR}px`);
+
+  if ('startViewTransition' in document && typeof document.startViewTransition === 'function') {
+    root.classList.add('theme-switching');
+    const t = document.startViewTransition(() => apply());
+    t.finished.then(() => root.classList.remove('theme-switching'));
+  } else {
+    apply();
+  }
+}
+
 export default function MobileScrollHeader() {
   const [visible, setVisible] = useState(false);
-  const [menuOpen, setMenuOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
-  const { isDarkMode, logoSrcs, toggleDarkMode } = useTheme();
-  const router = useRouter();
+  const { isDarkMode, toggleDarkMode, logoSrcs } = useTheme();
 
-  const mobileLogoSrc = isDarkMode
+  const logoSrc = isDarkMode
     ? logoSrcs?.mobileDark ?? '/logo-dark-mobile.svg'
     : logoSrcs?.mobileLight ?? '/logo-light-mobile.svg';
 
@@ -39,70 +54,61 @@ export default function MobileScrollHeader() {
     };
   }, []);
 
-  const handleNavClick = (e: React.MouseEvent<HTMLAnchorElement>, href: string) => {
-    if (e.ctrlKey || e.metaKey || e.shiftKey || e.altKey || e.button !== 0) return;
-    if (!href.startsWith('/')) return;
-    e.preventDefault();
-    setMenuOpen(false);
-    router.push(href);
-  };
-
   return (
     <>
       <div
-        className={`fixed top-0 left-0 right-0 z-40 bg-bg-main border-b border-border-main safe-area-top transition-transform duration-300 ease-out lg:hidden ${
+        className={`fixed top-0 left-0 right-0 z-40 bg-bg-main border-b border-border-main safe-area-top transition-transform duration-300 ease-out md:hidden ${
           visible ? 'translate-y-0' : '-translate-y-full'
         }`}
         aria-hidden={!visible}
       >
-        <div className="mx-auto max-w-[1280px] px-4">
-          <div className="grid h-[56px] grid-cols-[1fr_auto_1fr] items-center">
-            <div className="flex justify-start">
-              <button
-                onClick={() => setMenuOpen(true)}
-                className="flex h-9 w-9 items-center justify-center text-text-main"
-                aria-label="Open menu"
-              >
-                <Menu className="h-5 w-5" />
-              </button>
-            </div>
-            <Link
-              href="/"
-              className="relative block h-[56px] w-[min(60vw,240px)] justify-self-center"
-            >
+        <div className="relative flex items-center h-[56px] px-4">
+          <Link href="/" className="absolute left-1/2 -translate-x-1/2">
+            <div className="relative h-[56px] w-[180px]">
               <Image
-                src={mobileLogoSrc}
+                src={logoSrc}
                 alt="The Polytechnic"
                 fill
                 className="object-contain"
                 priority={false}
               />
-            </Link>
-            <div className="flex justify-end">
-              <button
-                onClick={() => setSearchOpen(true)}
-                className="flex h-9 w-9 items-center justify-center text-text-main"
-                aria-label="Search"
-              >
-                <Search className="h-5 w-5" />
-              </button>
             </div>
+          </Link>
+
+          <div className="ml-auto flex items-center gap-2">
+            <button
+              onClick={(e) => {
+                const rect = e.currentTarget.getBoundingClientRect();
+                triggerThemeTransition(
+                  rect.left + rect.width / 2,
+                  rect.top + rect.height / 2,
+                  () => toggleDarkMode(),
+                );
+              }}
+              className={`flex h-9 w-9 cursor-pointer items-center justify-center rounded-full transition-colors ${
+                isDarkMode
+                  ? 'text-text-main hover:bg-white hover:text-black'
+                  : 'text-text-main hover:bg-black hover:text-white'
+              }`}
+              aria-label={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+            >
+              {isDarkMode ? <Sun className="h-[18px] w-[18px]" /> : <Moon className="h-[18px] w-[18px]" />}
+            </button>
+
+            <button
+              onClick={() => setSearchOpen(true)}
+              className={`flex h-9 w-9 cursor-pointer items-center justify-center rounded-full transition-colors ${
+                isDarkMode
+                  ? 'text-text-main hover:bg-white/10'
+                  : 'text-text-main hover:bg-black/6'
+              }`}
+              aria-label="Search"
+            >
+              <Search className="h-[18px] w-[18px]" />
+            </button>
           </div>
         </div>
       </div>
-
-      <MobileMenuDrawer
-        isOpen={menuOpen}
-        onClose={() => setMenuOpen(false)}
-        onOpen={() => setMenuOpen(true)}
-        handleLinkClick={handleNavClick}
-        isDarkMode={isDarkMode}
-        onThemeToggle={toggleDarkMode}
-        onSearchOpen={() => {
-          setMenuOpen(false);
-          setSearchOpen(true);
-        }}
-      />
 
       {searchOpen && <SearchOverlay onClose={() => setSearchOpen(false)} />}
     </>

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -154,13 +154,30 @@ export default function ThemeProvider({
 
     // Android app bridge: drive the native status + nav bars from the in-app
     // theme so they follow the site toggle rather than the phone's ui mode.
-    // window.PolyTheme is only present when loaded inside the Capacitor shell.
-    try {
-      const polyTheme = (window as unknown as { PolyTheme?: { setDark?: (dark: boolean) => void } }).PolyTheme;
-      polyTheme?.setDark?.(isDarkMode);
-    } catch {
-      /* bridge unavailable (web browser or iOS) */
-    }
+    // window.PolyTheme may attach slightly after initial hydration, so we
+    // retry briefly until the interface shows up. No-op on browsers and iOS.
+    let cancelled = false;
+    let attempts = 0;
+    const pushTheme = () => {
+      if (cancelled) return;
+      const polyTheme = (window as unknown as { PolyTheme?: { setDark?: (d: boolean) => void } }).PolyTheme;
+      if (polyTheme?.setDark) {
+        try {
+          polyTheme.setDark(isDarkMode);
+        } catch {
+          /* swallow */
+        }
+        return;
+      }
+      if (attempts++ < 30) {
+        window.setTimeout(pushTheme, 100);
+      }
+    };
+    pushTheme();
+
+    return () => {
+      cancelled = true;
+    };
   }, [isDarkMode, isStandalonePwa]);
 
   const toggleDarkMode = () => {


### PR DESCRIPTION
Three fixes bundled for the mobile scroll header + its native-theme bridge.

## 1. Match ArticleStaticHeader layout
Drops the menu button. Logo centered, theme toggle + search on the right, same view-transition animation as the main header. Matches the article pages' mini header exactly.

## 2. Fix double-header on tablets / landscape phones
\`MobileScrollHeader\` used \`lg:hidden\` (shows up to 1023px); \`ArticleStaticHeader\` uses \`hidden md:block\` (shows 768px+). Overlap zone: **768–1023px** — tablets or phones in landscape saw both stacked. Changed to \`md:hidden\` so they never coexist.

## 3. Persist in-app theme on Android app reopen
The \`PolyTheme.setDark(...)\` bridge call in \`ThemeProvider\` used to fail silently on the very first page load because \`addJavascriptInterface\` hadn't attached the bridge yet when React's effect ran. Symptom: closing and reopening the Android app reset the status + nav bars to the phone's system theme even though the site itself stayed dark. Fix is a short retry loop (up to ~3 seconds) so the bridge call lands as soon as the interface is in the JS context.

## Test plan
- [ ] Mobile web, scroll past 220px anywhere → mini header slides in; logo + moon/sun + search (no menu).
- [ ] Phone in landscape on an article page → exactly one header visible.
- [ ] Android app: toggle in-app theme to dark, close app, reopen → bars come up dark without a visible flash.
- [ ] Desktop article page → unchanged; \`ArticleStaticHeader\` still the only fixed header.