### PR TITLE
feat(transcribe): audio upload + WhisperX transcription with custom Payload editor

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,12 @@ jobs:
             "NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}" \
             "NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}" \
             "NEXT_PUBLIC_POSTHOG_HOST=${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}" \
+            "TRANSCRIBE_API_URL=${{ secrets.TRANSCRIBE_API_URL }}" \
+            "TRANSCRIBE_API_KEY=${{ secrets.TRANSCRIBE_API_KEY }}" \
+            "TRANSCRIBE_CF_ACCESS_CLIENT_ID=${{ secrets.TRANSCRIBE_CF_ACCESS_CLIENT_ID }}" \
+            "TRANSCRIBE_CF_ACCESS_CLIENT_SECRET=${{ secrets.TRANSCRIBE_CF_ACCESS_CLIENT_SECRET }}" \
+            "TRANSCRIBE_PUBLIC_BASE_URL=${{ secrets.TRANSCRIBE_PUBLIC_BASE_URL }}" \
+            "AUDIO_DIR=/var/www/polymer-media/audio" \
             > "$SHARED_DIR/.env"
 
           # Runtime may not use the same UNIX user as the deploy runner.

--- a/app/api/transcribe/[id]/audio/route.ts
+++ b/app/api/transcribe/[id]/audio/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from 'next/server'
+import { createReadStream, statSync, existsSync } from 'node:fs'
+import path from 'node:path'
+import { Readable } from 'node:stream'
+import { getPayload } from 'payload'
+import config from '@/payload.config'
+
+const audioDir = process.env.AUDIO_DIR || '/var/www/polymer-media/audio'
+
+function safeJoin(base: string, name: string): string | null {
+  // Reject any filename that would escape the base dir.
+  if (!name || name.includes('/') || name.includes('\\') || name.startsWith('.')) return null
+  const resolved = path.resolve(base, name)
+  const baseResolved = path.resolve(base)
+  if (!resolved.startsWith(baseResolved + path.sep) && resolved !== baseResolved) return null
+  return resolved
+}
+
+export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params
+  const payload = await getPayload({ config })
+  const { user } = await payload.auth({ headers: req.headers })
+  if (!user) return new NextResponse('unauthorized', { status: 401 })
+  const job = await payload
+    .findByID({ collection: 'audio-jobs', id, depth: 1 })
+    .catch(() => null)
+  if (!job) return new NextResponse('not found', { status: 404 })
+
+  const audioFile = typeof job.audioFile === 'object' ? job.audioFile : null
+  if (!audioFile?.filename) return new NextResponse('no audio', { status: 404 })
+
+  const fp = safeJoin(audioDir, audioFile.filename)
+  if (!fp || !existsSync(fp)) return new NextResponse('audio missing', { status: 404 })
+
+  const stat = statSync(fp)
+  const range = req.headers.get('range')
+  if (range) {
+    const match = /bytes=(\d+)-(\d+)?/.exec(range)
+    if (match) {
+      const start = Number(match[1])
+      const end = match[2] ? Number(match[2]) : stat.size - 1
+      const stream = createReadStream(fp, { start, end })
+      return new NextResponse(Readable.toWeb(stream) as ReadableStream, {
+        status: 206,
+        headers: {
+          'Content-Range': `bytes ${start}-${end}/${stat.size}`,
+          'Accept-Ranges': 'bytes',
+          'Content-Length': String(end - start + 1),
+          'Content-Type': audioFile.mimeType || 'audio/mpeg',
+        },
+      })
+    }
+  }
+  const stream = createReadStream(fp)
+  return new NextResponse(Readable.toWeb(stream) as ReadableStream, {
+    status: 200,
+    headers: {
+      'Content-Length': String(stat.size),
+      'Accept-Ranges': 'bytes',
+      'Content-Type': audioFile.mimeType || 'audio/mpeg',
+    },
+  })
+}

--- a/app/api/transcribe/[id]/dispatch/route.ts
+++ b/app/api/transcribe/[id]/dispatch/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+import { randomBytes } from 'node:crypto'
+import { unlink } from 'node:fs/promises'
+import path from 'node:path'
+import config from '@/payload.config'
+import { dispatchToTranscribeApi } from '@/lib/transcribe/dispatch'
+import { transcodeToOpus } from '@/lib/transcribe/ffmpeg'
+import { getTranscribeConfig } from '@/lib/transcribe/config'
+
+export async function POST(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params
+  const payload = await getPayload({ config })
+  const { user } = await payload.auth({ headers: req.headers })
+  if (!user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const job = await payload
+    .findByID({ collection: 'audio-jobs', id, depth: 1 })
+    .catch(() => null)
+  if (!job) return NextResponse.json({ error: 'not found' }, { status: 404 })
+
+  const audioFile = typeof job.audioFile === 'object' ? job.audioFile : null
+  if (!audioFile?.filename) {
+    return NextResponse.json({ error: 'no audio file' }, { status: 409 })
+  }
+
+  const cfg = getTranscribeConfig()
+  if (!cfg.configured) {
+    return NextResponse.json({ error: 'transcribe API not configured' }, { status: 503 })
+  }
+
+  const audioDir = process.env.AUDIO_DIR || '/var/www/polymer-media/audio'
+  const audioPath = path.join(audioDir, audioFile.filename)
+  const opusPath = path.join(audioDir, `.tmp-${randomBytes(4).toString('hex')}.opus`)
+  const callbackSecret = randomBytes(32).toString('hex')
+  const audioJobId = typeof job.id === 'string' ? Number(job.id) : (job.id as number)
+
+  await payload.update({
+    collection: 'audio-jobs',
+    id: audioJobId,
+    data: {
+      status: 'queued',
+      dispatchAttempts: 0,
+      error: null,
+      callbackSecret,
+    },
+  })
+
+  void (async () => {
+    try {
+      await payload.update({
+        collection: 'audio-jobs',
+        id: audioJobId,
+        data: { status: 'dispatching' },
+      })
+      await transcodeToOpus(audioPath, opusPath)
+      const result = await dispatchToTranscribeApi({
+        audioPath: opusPath,
+        audioFilename: 'audio.opus',
+        audioMimeType: 'audio/opus',
+        audioJobId,
+        callbackSecret,
+      })
+      await payload.update({
+        collection: 'audio-jobs',
+        id: audioJobId,
+        data: { status: 'processing', externalJobId: result.externalJobId },
+      })
+    } catch (e) {
+      await payload.update({
+        collection: 'audio-jobs',
+        id: audioJobId,
+        data: { status: 'failed', error: String(e) },
+      })
+    } finally {
+      await unlink(opusPath).catch(() => {})
+    }
+  })()
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/transcribe/[id]/route.ts
+++ b/app/api/transcribe/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+import config from '@/payload.config'
+
+export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params
+  const payload = await getPayload({ config })
+  const { user } = await payload.auth({ headers: req.headers })
+  if (!user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  const job = await payload
+    .findByID({ collection: 'audio-jobs', id })
+    .catch(() => null)
+  if (!job) return NextResponse.json({ error: 'not found' }, { status: 404 })
+  return NextResponse.json({
+    id: job.id,
+    status: job.status,
+    progress: job.progress,
+    error: job.error,
+    transcribedAt: job.transcribedAt,
+    title: job.title,
+    kind: job.kind,
+  })
+}

--- a/app/api/transcribe/[id]/transcript/route.ts
+++ b/app/api/transcribe/[id]/transcript/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+import config from '@/payload.config'
+import type { TranscriptData } from '@/lib/transcribe/types'
+
+export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params
+  const payload = await getPayload({ config })
+  const { user } = await payload.auth({ headers: req.headers })
+  if (!user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  const found = await payload.find({
+    collection: 'transcripts',
+    where: { audioJob: { equals: id } },
+    limit: 1,
+  })
+  const t = found.docs[0]
+  if (!t) return NextResponse.json({ error: 'not found' }, { status: 404 })
+  return NextResponse.json({ id: t.id, data: t.data, editedAt: t.editedAt })
+}
+
+export async function PATCH(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params
+  const payload = await getPayload({ config })
+  const { user } = await payload.auth({ headers: req.headers })
+  if (!user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const body = (await req.json()) as { data?: TranscriptData }
+  if (!body.data || !Array.isArray(body.data.segments)) {
+    return NextResponse.json({ error: 'data.segments required' }, { status: 400 })
+  }
+
+  const found = await payload.find({
+    collection: 'transcripts',
+    where: { audioJob: { equals: id } },
+    limit: 1,
+  })
+  const t = found.docs[0]
+  if (!t) return NextResponse.json({ error: 'not found' }, { status: 404 })
+
+  const searchableText = body.data.segments.map((s) => s.text).join(' ')
+  await payload.update({
+    collection: 'transcripts',
+    id: t.id,
+    data: {
+      data: body.data as unknown as Record<string, unknown>,
+      searchableText,
+      editedAt: new Date().toISOString(),
+      editedBy: typeof user.id === 'string' ? Number(user.id) : (user.id as number),
+    },
+  })
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/transcribe/search/route.ts
+++ b/app/api/transcribe/search/route.ts
@@ -4,10 +4,16 @@ import pg from 'pg'
 import config from '@/payload.config'
 import { findMatchRanges, type HighlightRange } from '@/lib/transcribe/highlight'
 
+export const dynamic = 'force-dynamic'
+
 let pool: pg.Pool | null = null
 function getPool(): pg.Pool {
   if (!pool) {
-    pool = new pg.Pool({ connectionString: process.env.DATABASE_URL })
+    pool = new pg.Pool({
+      connectionString: process.env.DATABASE_URL,
+      max: 2,
+      idleTimeoutMillis: 10_000,
+    })
   }
   return pool
 }

--- a/app/api/transcribe/search/route.ts
+++ b/app/api/transcribe/search/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+import pg from 'pg'
+import config from '@/payload.config'
+import { findMatchRanges, type HighlightRange } from '@/lib/transcribe/highlight'
+
+let pool: pg.Pool | null = null
+function getPool(): pg.Pool {
+  if (!pool) {
+    pool = new pg.Pool({ connectionString: process.env.DATABASE_URL })
+  }
+  return pool
+}
+
+const STAFF_VIEW_ROLES = ['admin', 'eic', 'editor']
+
+interface SearchRow {
+  transcript_id: number
+  audio_job_id: number
+  title: string
+  kind: string
+  uploader_id: number
+  searchable_text: string
+  rank: number
+}
+
+interface SnippetResult {
+  transcript_id: number
+  audio_job_id: number
+  title: string
+  kind: string
+  uploader_id: number
+  snippet: string
+  ranges: HighlightRange[]
+  rank: number
+}
+
+const SNIPPET_MAX = 240
+
+function buildSnippet(text: string, ranges: HighlightRange[]): { snippet: string; ranges: HighlightRange[] } {
+  if (!ranges.length) return { snippet: text.slice(0, SNIPPET_MAX), ranges: [] }
+  const first = ranges[0]
+  const radius = Math.floor(SNIPPET_MAX / 2)
+  let start = Math.max(0, first.start - radius)
+  let end = Math.min(text.length, start + SNIPPET_MAX)
+  // Trim to nearest word boundaries when possible.
+  if (start > 0) {
+    const ws = text.lastIndexOf(' ', start)
+    if (ws > 0) start = ws + 1
+  }
+  if (end < text.length) {
+    const ws = text.indexOf(' ', end)
+    if (ws > 0 && ws - start <= SNIPPET_MAX + 40) end = ws
+  }
+  const snippet = (start > 0 ? '… ' : '') + text.slice(start, end) + (end < text.length ? ' …' : '')
+  const offset = start > 0 ? 2 : 0
+  const adjustedRanges = ranges
+    .map((r) => ({ start: r.start - start + offset, end: r.end - start + offset }))
+    .filter((r) => r.end > 0 && r.start < snippet.length)
+    .map((r) => ({ start: Math.max(0, r.start), end: Math.min(snippet.length, r.end) }))
+  return { snippet, ranges: adjustedRanges }
+}
+
+export async function GET(req: Request) {
+  const payload = await getPayload({ config })
+  const { user } = await payload.auth({ headers: req.headers })
+  if (!user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  const url = new URL(req.url)
+  const q = (url.searchParams.get('q') ?? '').trim()
+  if (!q) return NextResponse.json({ results: [] })
+
+  const u = user as unknown as { id: number; roles?: string[] }
+  const isStaff = Boolean(u.roles?.some((r) => STAFF_VIEW_ROLES.includes(r)))
+
+  const sqlBase = `
+    SELECT t.id AS transcript_id,
+           t.audio_job_id,
+           j.title,
+           j.kind,
+           j.uploader_id,
+           coalesce(t.searchable_text, '') AS searchable_text,
+           ts_rank(to_tsvector('english', coalesce(t.searchable_text, '')),
+                   websearch_to_tsquery('english', $1)) AS rank
+      FROM transcripts t
+      JOIN audio_jobs j ON j.id = t.audio_job_id
+     WHERE to_tsvector('english', coalesce(t.searchable_text, '')) @@ websearch_to_tsquery('english', $1)
+  `
+  const sql = isStaff
+    ? `${sqlBase} ORDER BY rank DESC LIMIT 50`
+    : `${sqlBase} AND j.uploader_id = $2 ORDER BY rank DESC LIMIT 50`
+  const args = isStaff ? [q] : [q, u.id]
+
+  const { rows } = await getPool().query<SearchRow>(sql, args)
+  const results: SnippetResult[] = rows.map((row) => {
+    const ranges = findMatchRanges(row.searchable_text, q)
+    const { snippet, ranges: snippetRanges } = buildSnippet(row.searchable_text, ranges)
+    return {
+      transcript_id: row.transcript_id,
+      audio_job_id: row.audio_job_id,
+      title: row.title,
+      kind: row.kind,
+      uploader_id: row.uploader_id,
+      snippet,
+      ranges: snippetRanges,
+      rank: row.rank,
+    }
+  })
+  return NextResponse.json({ results })
+}

--- a/app/api/transcribe/upload/route.ts
+++ b/app/api/transcribe/upload/route.ts
@@ -1,0 +1,171 @@
+import { NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+import { randomBytes } from 'node:crypto'
+import { mkdtemp, writeFile, rm, unlink } from 'node:fs/promises'
+import path from 'node:path'
+import os from 'node:os'
+import config from '@/payload.config'
+import { ffprobe, transcodeToOpus } from '@/lib/transcribe/ffmpeg'
+import { dispatchToTranscribeApi } from '@/lib/transcribe/dispatch'
+import { getTranscribeConfig } from '@/lib/transcribe/config'
+
+const MAX_HOURS = 6
+const STAFF_ROLES = ['admin', 'eic', 'editor', 'writer']
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 300
+
+export async function POST(req: Request) {
+  const payload = await getPayload({ config })
+  const { user } = await payload.auth({ headers: req.headers })
+  if (!user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  const roles = (user as unknown as { roles?: string[] }).roles ?? []
+  if (!roles.some((r) => STAFF_ROLES.includes(r))) {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+  }
+
+  const form = await req.formData()
+  const audio = form.get('audio')
+  if (!(audio instanceof File)) {
+    return NextResponse.json({ error: 'audio file required' }, { status: 400 })
+  }
+  const title = String(form.get('title') ?? audio.name)
+  const kind = String(form.get('kind') ?? 'interview')
+  const notesRaw = form.get('notes')
+  const notes = typeof notesRaw === 'string' && notesRaw.length > 0 ? notesRaw : undefined
+
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'polymer-upload-'))
+  const tmpPath = path.join(tmpDir, audio.name)
+  const audioBuffer = Buffer.from(await audio.arrayBuffer())
+  await writeFile(tmpPath, audioBuffer)
+
+  try {
+    const probe = await ffprobe(tmpPath)
+    if (!probe.hasAudio) {
+      return NextResponse.json({ error: 'file has no audio stream' }, { status: 415 })
+    }
+    if (probe.durationSeconds > MAX_HOURS * 3600) {
+      return NextResponse.json(
+        { error: `audio exceeds ${MAX_HOURS} hours` },
+        { status: 400 },
+      )
+    }
+
+    const audioFile = await payload.create({
+      collection: 'audio-files',
+      file: {
+        data: audioBuffer,
+        mimetype: audio.type || 'application/octet-stream',
+        name: audio.name,
+        size: audio.size,
+      },
+      data: {
+        durationSeconds: probe.durationSeconds,
+        uploader: typeof user.id === 'string' ? Number(user.id) : (user.id as number),
+      },
+    })
+
+    const callbackSecret = randomBytes(32).toString('hex')
+    const job = await payload.create({
+      collection: 'audio-jobs',
+      data: {
+        title,
+        kind: kind as never,
+        notes,
+        audioFile: audioFile.id,
+        uploader: typeof user.id === 'string' ? Number(user.id) : (user.id as number),
+        status: 'queued',
+        callbackSecret,
+      },
+    })
+
+    const audioJobId = typeof job.id === 'string' ? Number(job.id) : (job.id as number)
+
+    void dispatchInBackground({
+      audioJobId,
+      audioFilePath: tmpPath,
+      tmpDir,
+      audioMimeType: audio.type || 'application/octet-stream',
+      callbackSecret,
+    })
+
+    return NextResponse.json({ id: job.id, status: 'queued' }, { status: 201 })
+  } catch (err) {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {})
+    throw err
+  }
+}
+
+interface BackgroundArgs {
+  audioJobId: number
+  audioFilePath: string
+  tmpDir: string
+  audioMimeType: string
+  callbackSecret: string
+}
+
+async function dispatchInBackground(args: BackgroundArgs): Promise<void> {
+  const payload = await getPayload({ config })
+  const cfg = getTranscribeConfig()
+  if (!cfg.configured) {
+    await payload.update({
+      collection: 'audio-jobs',
+      id: args.audioJobId,
+      data: {
+        status: 'failed',
+        error:
+          'TRANSCRIBE_API_URL/API_KEY/CF_ACCESS_* not configured on the server. See docs/superpowers/specs/2026-04-28-audio-transcription-design.md',
+      },
+    })
+    await rm(args.tmpDir, { recursive: true, force: true }).catch(() => {})
+    return
+  }
+
+  const opusPath = path.join(args.tmpDir, 'audio.opus')
+  try {
+    await payload.update({
+      collection: 'audio-jobs',
+      id: args.audioJobId,
+      data: { status: 'dispatching' },
+    })
+    await transcodeToOpus(args.audioFilePath, opusPath)
+
+    const result = await dispatchToTranscribeApi({
+      audioPath: opusPath,
+      audioFilename: 'audio.opus',
+      audioMimeType: 'audio/opus',
+      audioJobId: args.audioJobId,
+      callbackSecret: args.callbackSecret,
+    })
+    await payload.update({
+      collection: 'audio-jobs',
+      id: args.audioJobId,
+      data: { status: 'processing', externalJobId: result.externalJobId },
+    })
+  } catch (err) {
+    const job = await payload.findByID({ collection: 'audio-jobs', id: args.audioJobId })
+    const attempts = (job.dispatchAttempts ?? 0) + 1
+    if (attempts >= 3) {
+      await payload.update({
+        collection: 'audio-jobs',
+        id: args.audioJobId,
+        data: { status: 'failed', error: String(err), dispatchAttempts: attempts },
+      })
+    } else {
+      const backoffMs = [60_000, 300_000, 1_500_000][attempts - 1] ?? 60_000
+      await payload.update({
+        collection: 'audio-jobs',
+        id: args.audioJobId,
+        data: { status: 'queued', dispatchAttempts: attempts, error: String(err) },
+      })
+      setTimeout(() => {
+        void dispatchInBackground(args)
+      }, backoffMs)
+      return
+    }
+  } finally {
+    await unlink(opusPath).catch(() => {})
+  }
+
+  await rm(args.tmpDir, { recursive: true, force: true }).catch(() => {})
+}

--- a/app/api/transcribe/webhook/route.ts
+++ b/app/api/transcribe/webhook/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+import config from '@/payload.config'
+import { verifySignature } from '@/lib/transcribe/hmac'
+import type { TranscribeWebhookBody, TranscriptData } from '@/lib/transcribe/types'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(req: Request) {
+  const raw = await req.text()
+  const sig = req.headers.get('x-polymer-transcribe-signature')
+
+  let body: TranscribeWebhookBody
+  try {
+    body = JSON.parse(raw) as TranscribeWebhookBody
+  } catch {
+    return NextResponse.json({ error: 'bad json' }, { status: 400 })
+  }
+
+  const audioJobId = body.metadata?.audioJobId
+  if (!audioJobId) {
+    return NextResponse.json({ error: 'missing metadata.audioJobId' }, { status: 400 })
+  }
+
+  const payload = await getPayload({ config })
+  const job = await payload
+    .findByID({ collection: 'audio-jobs', id: audioJobId, overrideAccess: true })
+    .catch(() => null)
+  if (!job) return NextResponse.json({ error: 'unknown job' }, { status: 404 })
+  if (!job.callbackSecret) {
+    return NextResponse.json({ error: 'no callback secret' }, { status: 409 })
+  }
+  if (!verifySignature(raw, sig, job.callbackSecret)) {
+    return NextResponse.json({ error: 'bad signature' }, { status: 401 })
+  }
+
+  if (body.status === 'failed' || !body.result) {
+    await payload.update({
+      collection: 'audio-jobs',
+      id: audioJobId,
+      overrideAccess: true,
+      data: { status: 'failed', error: body.error ?? 'unknown error' },
+    })
+    return NextResponse.json({ ok: true })
+  }
+
+  const r = body.result
+  const data: TranscriptData = {
+    language: r.language,
+    duration: r.duration,
+    model: r.model,
+    speakers: r.speakers.map((s) => ({ id: s.id, label: null })),
+    segments: r.segments.map((s) => ({
+      id: s.id,
+      speakerId: s.speaker_id,
+      start: s.start,
+      end: s.end,
+      text: s.text,
+      words: s.words.map((w) => ({
+        word: w.word,
+        start: w.start,
+        end: w.end,
+        score: w.score,
+      })),
+    })),
+  }
+  const searchableText = data.segments.map((s) => s.text).join(' ')
+
+  const existing = await payload.find({
+    collection: 'transcripts',
+    where: { audioJob: { equals: audioJobId } },
+    limit: 1,
+    overrideAccess: true,
+  })
+  // Payload's `json` field type expects an indexable record; TranscriptData
+  // is structurally compatible but TS doesn't infer the index signature.
+  const dataRecord = data as unknown as Record<string, unknown>
+  if (existing.docs[0]) {
+    await payload.update({
+      collection: 'transcripts',
+      id: existing.docs[0].id,
+      overrideAccess: true,
+      data: { data: dataRecord, searchableText },
+    })
+  } else {
+    await payload.create({
+      collection: 'transcripts',
+      overrideAccess: true,
+      data: { audioJob: audioJobId, data: dataRecord, searchableText },
+    })
+  }
+  await payload.update({
+    collection: 'audio-jobs',
+    id: audioJobId,
+    overrideAccess: true,
+    data: { status: 'completed', transcribedAt: new Date().toISOString(), error: null },
+  })
+
+  return NextResponse.json({ ok: true })
+}

--- a/collections/AudioFiles.ts
+++ b/collections/AudioFiles.ts
@@ -1,0 +1,80 @@
+import type { CollectionConfig, Access } from 'payload'
+
+type UserWithRoles = { id: string | number; roles?: string[] }
+
+const STAFF_ROLES = ['admin', 'eic', 'editor', 'writer']
+const STAFF_VIEW_ROLES = ['admin', 'eic', 'editor']
+
+const isStaff: Access = ({ req: { user } }) => {
+  const u = user as unknown as UserWithRoles | undefined
+  return Boolean(u?.roles?.some((r) => STAFF_ROLES.includes(r)))
+}
+
+const isAdmin: Access = ({ req: { user } }) => {
+  const u = user as unknown as UserWithRoles | undefined
+  return Boolean(u?.roles?.includes('admin'))
+}
+
+export const AudioFiles: CollectionConfig = {
+  slug: 'audio-files',
+  admin: {
+    useAsTitle: 'filename',
+    defaultColumns: ['filename', 'durationSeconds', 'uploader', 'createdAt'],
+    description: 'Raw audio uploads. Linked to audio-jobs.',
+    hidden: ({ user }) => {
+      const u = user as unknown as UserWithRoles | undefined
+      return !u?.roles?.includes('admin')
+    },
+  },
+  access: {
+    read: ({ req: { user } }) => {
+      if (!user) return false
+      const u = user as unknown as UserWithRoles
+      if (u.roles?.some((r) => STAFF_VIEW_ROLES.includes(r))) return true
+      return { uploader: { equals: user.id } }
+    },
+    create: isStaff,
+    update: () => false,
+    delete: isAdmin,
+  },
+  upload: {
+    staticDir: process.env.AUDIO_DIR || '/var/www/polymer-media/audio',
+    mimeTypes: [
+      'audio/mpeg',
+      'audio/mp4',
+      'audio/x-m4a',
+      'audio/wav',
+      'audio/x-wav',
+      'audio/ogg',
+      'audio/flac',
+      'audio/webm',
+      'audio/opus',
+    ],
+  },
+  fields: [
+    {
+      name: 'durationSeconds',
+      type: 'number',
+      admin: { readOnly: true },
+    },
+    {
+      name: 'uploader',
+      type: 'relationship',
+      relationTo: 'users',
+      admin: { position: 'sidebar', readOnly: true },
+    },
+  ],
+  hooks: {
+    beforeChange: [
+      ({ req, data, operation }) => {
+        if (operation === 'create' && req.user) {
+          data.uploader = req.user.id
+        }
+        return data
+      },
+    ],
+  },
+  timestamps: true,
+}
+
+export default AudioFiles

--- a/collections/AudioJobs.ts
+++ b/collections/AudioJobs.ts
@@ -1,0 +1,120 @@
+import type { CollectionConfig, Access } from 'payload'
+
+type UserWithRoles = { id: string | number; roles?: string[] }
+
+const STAFF_ROLES = ['admin', 'eic', 'editor', 'writer']
+const STAFF_VIEW_ROLES = ['admin', 'eic', 'editor']
+
+const isStaff: Access = ({ req: { user } }) => {
+  const u = user as unknown as UserWithRoles | undefined
+  return Boolean(u?.roles?.some((r) => STAFF_ROLES.includes(r)))
+}
+
+const ownOrStaffView: Access = ({ req: { user } }) => {
+  if (!user) return false
+  const u = user as unknown as UserWithRoles
+  if (u.roles?.some((r) => STAFF_VIEW_ROLES.includes(r))) return true
+  return { uploader: { equals: user.id } }
+}
+
+const ownOrAdmin: Access = ({ req: { user } }) => {
+  if (!user) return false
+  const u = user as unknown as UserWithRoles
+  if (u.roles?.includes('admin')) return true
+  return { uploader: { equals: user.id } }
+}
+
+export const AudioJobs: CollectionConfig = {
+  slug: 'audio-jobs',
+  labels: { singular: 'Transcript', plural: 'Transcripts' },
+  admin: {
+    useAsTitle: 'title',
+    defaultColumns: ['title', 'kind', 'status', 'uploader', 'createdAt'],
+    group: 'Newsroom',
+  },
+  access: {
+    read: ownOrStaffView,
+    create: isStaff,
+    update: ownOrAdmin,
+    delete: ownOrAdmin,
+  },
+  fields: [
+    { name: 'title', type: 'text', required: true },
+    {
+      name: 'kind',
+      type: 'select',
+      required: true,
+      defaultValue: 'interview',
+      options: [
+        { label: 'Interview', value: 'interview' },
+        { label: 'Meeting', value: 'meeting' },
+        { label: 'Press Conference', value: 'presser' },
+        { label: 'Lecture', value: 'lecture' },
+        { label: 'Court / Hearing', value: 'court' },
+        { label: 'Other', value: 'other' },
+      ],
+    },
+    { name: 'notes', type: 'textarea' },
+    {
+      name: 'audioFile',
+      type: 'relationship',
+      relationTo: 'audio-files',
+      required: true,
+      admin: { readOnly: true },
+    },
+    {
+      name: 'uploader',
+      type: 'relationship',
+      relationTo: 'users',
+      admin: { position: 'sidebar', readOnly: true },
+    },
+    {
+      name: 'status',
+      type: 'select',
+      required: true,
+      defaultValue: 'queued',
+      options: [
+        { label: 'Queued', value: 'queued' },
+        { label: 'Dispatching', value: 'dispatching' },
+        { label: 'Processing', value: 'processing' },
+        { label: 'Completed', value: 'completed' },
+        { label: 'Failed', value: 'failed' },
+      ],
+      admin: { readOnly: true, position: 'sidebar' },
+    },
+    {
+      name: 'externalJobId',
+      type: 'text',
+      admin: { readOnly: true, hidden: true },
+    },
+    {
+      name: 'callbackSecret',
+      type: 'text',
+      admin: { readOnly: true, hidden: true },
+    },
+    { name: 'progress', type: 'number', admin: { readOnly: true, hidden: true } },
+    { name: 'dispatchAttempts', type: 'number', defaultValue: 0, admin: { hidden: true } },
+    {
+      name: 'error',
+      type: 'textarea',
+      admin: {
+        readOnly: true,
+        condition: (data) => Boolean(data?.error),
+      },
+    },
+    { name: 'transcribedAt', type: 'date', admin: { readOnly: true, hidden: true } },
+  ],
+  hooks: {
+    beforeChange: [
+      ({ req, data, operation }) => {
+        if (operation === 'create' && req.user && !data.uploader) {
+          data.uploader = req.user.id
+        }
+        return data
+      },
+    ],
+  },
+  timestamps: true,
+}
+
+export default AudioJobs

--- a/collections/AudioJobs.ts
+++ b/collections/AudioJobs.ts
@@ -31,6 +31,16 @@ export const AudioJobs: CollectionConfig = {
     useAsTitle: 'title',
     defaultColumns: ['title', 'kind', 'status', 'uploader', 'createdAt'],
     group: 'Newsroom',
+    components: {
+      views: {
+        list: { Component: '@/components/Transcribe/JobsListView#default' },
+        edit: {
+          default: {
+            Component: '@/components/Transcribe/JobEditView#default',
+          },
+        },
+      },
+    },
   },
   access: {
     read: ownOrStaffView,

--- a/collections/Transcripts.ts
+++ b/collections/Transcripts.ts
@@ -1,0 +1,58 @@
+import type { CollectionConfig, Access } from 'payload'
+
+type UserWithRoles = { id: string | number; roles?: string[] }
+
+const isAuthed: Access = ({ req: { user } }) => Boolean(user)
+
+const isAdmin: Access = ({ req: { user } }) => {
+  const u = user as unknown as UserWithRoles | undefined
+  return Boolean(u?.roles?.includes('admin'))
+}
+
+export const Transcripts: CollectionConfig = {
+  slug: 'transcripts',
+  admin: {
+    useAsTitle: 'id',
+    description:
+      'Transcript JSON blobs linked 1:1 with audio-jobs. Edited via the custom audio-jobs admin view, not directly here.',
+    hidden: ({ user }) => {
+      const u = user as unknown as UserWithRoles | undefined
+      return !u?.roles?.includes('admin')
+    },
+  },
+  access: {
+    // Route handlers enforce ownership against the linked audio-job. Payload
+    // access here intentionally allows any authenticated user to read; the
+    // admin UI never surfaces transcripts directly, only through audio-jobs.
+    read: isAuthed,
+    create: isAuthed,
+    update: isAuthed,
+    delete: isAdmin,
+  },
+  fields: [
+    {
+      name: 'audioJob',
+      type: 'relationship',
+      relationTo: 'audio-jobs',
+      required: true,
+      unique: true,
+      admin: { readOnly: true },
+    },
+    { name: 'data', type: 'json', required: true },
+    {
+      name: 'searchableText',
+      type: 'textarea',
+      admin: { hidden: true },
+    },
+    { name: 'editedAt', type: 'date', admin: { readOnly: true } },
+    {
+      name: 'editedBy',
+      type: 'relationship',
+      relationTo: 'users',
+      admin: { readOnly: true },
+    },
+  ],
+  timestamps: true,
+}
+
+export default Transcripts

--- a/components/Transcribe/Editor/AudioPlayer.tsx
+++ b/components/Transcribe/Editor/AudioPlayer.tsx
@@ -1,0 +1,20 @@
+'use client'
+import { forwardRef } from 'react'
+
+interface Props {
+  audioJobId: string
+}
+
+const AudioPlayer = forwardRef<HTMLAudioElement, Props>(function AudioPlayer({ audioJobId }, ref) {
+  return (
+    <audio
+      ref={ref}
+      src={`/api/transcribe/${audioJobId}/audio`}
+      controls
+      preload="metadata"
+      style={{ width: '100%' }}
+    />
+  )
+})
+
+export default AudioPlayer

--- a/components/Transcribe/Editor/Editor.tsx
+++ b/components/Transcribe/Editor/Editor.tsx
@@ -1,8 +1,128 @@
 'use client'
-export default function Editor({ audioJobId }: { audioJobId: string; title: string; kind: string }) {
+import { useCallback, useMemo, useRef } from 'react'
+import { useTranscript } from '../hooks/useTranscript'
+import { useAudioPlayback } from '../hooks/useAudioPlayback'
+import AudioPlayer from './AudioPlayer'
+import SegmentList from './SegmentList'
+import SpeakerSidebar from './SpeakerSidebar'
+import type { TranscriptData } from '@/lib/transcribe/types'
+
+interface Props {
+  audioJobId: string
+  title: string
+  kind: string
+}
+
+export default function Editor({ audioJobId, title }: Props) {
+  const { data, update, saveState } = useTranscript(audioJobId)
+  const audioRef = useRef<HTMLAudioElement>(null)
+  const pos = useAudioPlayback(audioRef, data)
+
+  const segmentCounts = useMemo(() => {
+    if (!data) return {}
+    const acc: Record<string, number> = {}
+    for (const s of data.segments) acc[s.speakerId] = (acc[s.speakerId] ?? 0) + 1
+    return acc
+  }, [data])
+
+  const onSeek = useCallback((t: number) => {
+    if (audioRef.current) {
+      audioRef.current.currentTime = t
+      void audioRef.current.play()
+    }
+  }, [])
+
+  const onTextChange = useCallback(
+    (id: string, text: string) => {
+      if (!data) return
+      update({
+        ...data,
+        segments: data.segments.map((s) =>
+          s.id === id ? { ...s, text, edited: true } : s,
+        ),
+      })
+    },
+    [data, update],
+  )
+
+  const onSpeakerChange = useCallback(
+    (id: string, speakerId: string) => {
+      if (!data) return
+      const speakers = data.speakers.some((sp) => sp.id === speakerId)
+        ? data.speakers
+        : [...data.speakers, { id: speakerId, label: null }]
+      update({
+        ...data,
+        speakers,
+        segments: data.segments.map((s) => (s.id === id ? { ...s, speakerId } : s)),
+      })
+    },
+    [data, update],
+  )
+
+  const onRename = useCallback(
+    (id: string, label: string) => {
+      if (!data) return
+      update({
+        ...data,
+        speakers: data.speakers.map((sp) =>
+          sp.id === id ? { ...sp, label: label || null } : sp,
+        ),
+      })
+    },
+    [data, update],
+  )
+
+  // Phase 5 utilities are wired here as no-ops for now; replaced when Phase 5 lands.
+  const noopMerge = useCallback((_id: string) => {}, [])
+  const noopSplit = useCallback((_id: string, _wordIndex: number) => {}, [])
+
+  if (!data) return <div style={{ padding: '2rem' }}>Loading transcript…</div>
+
+  const saveText: Record<typeof saveState, string> = {
+    idle: '',
+    dirty: '● Unsaved',
+    saving: '○ Saving…',
+    saved: '✓ Saved',
+    error: 'Save failed',
+  }
+
   return (
-    <div style={{ padding: '2rem' }}>
-      Editor coming for job {audioJobId}…
+    <div className="transcribe-editor">
+      <header className="transcribe-editor__header">
+        <h2>{title || 'Transcript'}</h2>
+        <span
+          className={`transcribe-editor__save${
+            saveState === 'error' ? ' transcribe-editor__save--error' : ''
+          }`}
+        >
+          {saveText[saveState]}
+        </span>
+      </header>
+      <div className="transcribe-editor__player">
+        <AudioPlayer ref={audioRef} audioJobId={audioJobId} />
+      </div>
+      <div className="transcribe-editor__body">
+        <SpeakerSidebar
+          speakers={data.speakers}
+          segmentCounts={segmentCounts}
+          onRename={onRename}
+        />
+        <div className="transcribe-segment-list">
+          <SegmentList
+            segments={data.segments}
+            speakers={data.speakers}
+            currentSegmentId={pos.segmentId}
+            currentWordIndex={pos.wordIndex}
+            onSeek={onSeek}
+            onTextChange={onTextChange}
+            onSpeakerChange={onSpeakerChange}
+            onMergeAbove={noopMerge}
+            onMergeBelow={noopMerge}
+            onSplitAt={noopSplit}
+          />
+        </div>
+      </div>
     </div>
   )
 }

--- a/components/Transcribe/Editor/Editor.tsx
+++ b/components/Transcribe/Editor/Editor.tsx
@@ -1,10 +1,13 @@
 'use client'
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranscript } from '../hooks/useTranscript'
 import { useAudioPlayback } from '../hooks/useAudioPlayback'
 import AudioPlayer from './AudioPlayer'
 import SegmentList from './SegmentList'
 import SpeakerSidebar from './SpeakerSidebar'
+import FindReplace from './FindReplace'
+import ExportMenu from './ExportMenu'
+import { mergeSegments, splitSegment, reassignSpeaker } from '@/lib/transcribe/segments'
 import type { TranscriptData } from '@/lib/transcribe/types'
 
 interface Props {
@@ -14,9 +17,26 @@ interface Props {
 }
 
 export default function Editor({ audioJobId, title }: Props) {
-  const { data, update, saveState } = useTranscript(audioJobId)
+  const { data, update, forceSave, saveState } = useTranscript(audioJobId)
   const audioRef = useRef<HTMLAudioElement>(null)
   const pos = useAudioPlayback(audioRef, data)
+  const [showFind, setShowFind] = useState(false)
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
+        e.preventDefault()
+        setShowFind(true)
+      } else if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+        e.preventDefault()
+        void forceSave()
+      } else if (e.key === 'Escape') {
+        setShowFind(false)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [forceSave])
 
   const segmentCounts = useMemo(() => {
     if (!data) return {}
@@ -48,14 +68,33 @@ export default function Editor({ audioJobId, title }: Props) {
   const onSpeakerChange = useCallback(
     (id: string, speakerId: string) => {
       if (!data) return
-      const speakers = data.speakers.some((sp) => sp.id === speakerId)
-        ? data.speakers
-        : [...data.speakers, { id: speakerId, label: null }]
-      update({
-        ...data,
-        speakers,
-        segments: data.segments.map((s) => (s.id === id ? { ...s, speakerId } : s)),
-      })
+      update(reassignSpeaker(data, id, speakerId))
+    },
+    [data, update],
+  )
+
+  const onMergeAbove = useCallback(
+    (id: string) => {
+      if (!data) return
+      const idx = data.segments.findIndex((s) => s.id === id)
+      if (idx <= 0) return
+      update(mergeSegments(data, data.segments[idx - 1].id, id))
+    },
+    [data, update],
+  )
+  const onMergeBelow = useCallback(
+    (id: string) => {
+      if (!data) return
+      const idx = data.segments.findIndex((s) => s.id === id)
+      if (idx < 0 || idx >= data.segments.length - 1) return
+      update(mergeSegments(data, id, data.segments[idx + 1].id))
+    },
+    [data, update],
+  )
+  const onSplitAt = useCallback(
+    (id: string, wordIndex: number) => {
+      if (!data) return
+      update(splitSegment(data, id, wordIndex))
     },
     [data, update],
   )
@@ -73,10 +112,6 @@ export default function Editor({ audioJobId, title }: Props) {
     [data, update],
   )
 
-  // Phase 5 utilities are wired here as no-ops for now; replaced when Phase 5 lands.
-  const noopMerge = useCallback((_id: string) => {}, [])
-  const noopSplit = useCallback((_id: string, _wordIndex: number) => {}, [])
-
   if (!data) return <div style={{ padding: '2rem' }}>Loading transcript…</div>
 
   const saveText: Record<typeof saveState, string> = {
@@ -91,6 +126,25 @@ export default function Editor({ audioJobId, title }: Props) {
     <div className="transcribe-editor">
       <header className="transcribe-editor__header">
         <h2>{title || 'Transcript'}</h2>
+        <ExportMenu
+          data={data}
+          baseName={(title || 'transcript').replace(/[^a-z0-9-]+/gi, '_')}
+        />
+        <button
+          onClick={() => setShowFind(true)}
+          style={{
+            background: 'none',
+            border: '1px solid var(--theme-elevation-200, #ccc)',
+            borderRadius: 4,
+            padding: '0.25rem 0.6rem',
+            fontSize: 12,
+            cursor: 'pointer',
+            color: 'inherit',
+          }}
+          title="Find & Replace (⌘F)"
+        >
+          Find
+        </button>
         <span
           className={`transcribe-editor__save${
             saveState === 'error' ? ' transcribe-editor__save--error' : ''
@@ -117,12 +171,19 @@ export default function Editor({ audioJobId, title }: Props) {
             onSeek={onSeek}
             onTextChange={onTextChange}
             onSpeakerChange={onSpeakerChange}
-            onMergeAbove={noopMerge}
-            onMergeBelow={noopMerge}
-            onSplitAt={noopSplit}
+            onMergeAbove={onMergeAbove}
+            onMergeBelow={onMergeBelow}
+            onSplitAt={onSplitAt}
           />
         </div>
       </div>
+      {showFind && (
+        <FindReplace
+          data={data}
+          onApply={(next: TranscriptData) => update(next)}
+          onClose={() => setShowFind(false)}
+        />
+      )}
     </div>
   )
 }

--- a/components/Transcribe/Editor/Editor.tsx
+++ b/components/Transcribe/Editor/Editor.tsx
@@ -1,0 +1,8 @@
+'use client'
+export default function Editor({ audioJobId }: { audioJobId: string; title: string; kind: string }) {
+  return (
+    <div style={{ padding: '2rem' }}>
+      Editor coming for job {audioJobId}…
+    </div>
+  )
+}

--- a/components/Transcribe/Editor/ExportMenu.tsx
+++ b/components/Transcribe/Editor/ExportMenu.tsx
@@ -1,0 +1,44 @@
+'use client'
+import { buildPlainText, buildSrt, buildVtt, buildJson } from '@/lib/transcribe/exporters'
+import type { TranscriptData } from '@/lib/transcribe/types'
+
+function download(filename: string, mime: string, body: string) {
+  const blob = new Blob([body], { type: mime })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  setTimeout(() => URL.revokeObjectURL(url), 1000)
+}
+
+export default function ExportMenu({
+  data,
+  baseName,
+}: {
+  data: TranscriptData
+  baseName: string
+}) {
+  return (
+    <div className="transcribe-export">
+      <button
+        onClick={() => download(`${baseName}.txt`, 'text/plain', buildPlainText(data))}
+      >
+        TXT
+      </button>
+      <button
+        onClick={() => download(`${baseName}.srt`, 'application/x-subrip', buildSrt(data))}
+      >
+        SRT
+      </button>
+      <button onClick={() => download(`${baseName}.vtt`, 'text/vtt', buildVtt(data))}>VTT</button>
+      <button
+        onClick={() => download(`${baseName}.json`, 'application/json', buildJson(data))}
+      >
+        JSON
+      </button>
+    </div>
+  )
+}

--- a/components/Transcribe/Editor/FindReplace.tsx
+++ b/components/Transcribe/Editor/FindReplace.tsx
@@ -1,0 +1,89 @@
+'use client'
+import { useMemo, useState } from 'react'
+import type { TranscriptData } from '@/lib/transcribe/types'
+
+interface Props {
+  data: TranscriptData
+  onApply: (next: TranscriptData) => void
+  onClose: () => void
+}
+
+function escapeForRegex(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export default function FindReplace({ data, onApply, onClose }: Props) {
+  const [find, setFind] = useState('')
+  const [replace, setReplace] = useState('')
+  const [regex, setRegex] = useState(false)
+  const [caseSensitive, setCaseSensitive] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const pattern = useMemo<RegExp | null>(() => {
+    if (!find) return null
+    setError(null)
+    const flags = caseSensitive ? 'g' : 'gi'
+    try {
+      return regex ? new RegExp(find, flags) : new RegExp(escapeForRegex(find), flags)
+    } catch (e) {
+      setError(String(e))
+      return null
+    }
+  }, [find, regex, caseSensitive])
+
+  const matchCount = useMemo(() => {
+    if (!pattern) return 0
+    let n = 0
+    for (const s of data.segments) n += s.text.match(pattern)?.length ?? 0
+    return n
+  }, [pattern, data])
+
+  function apply() {
+    if (!pattern) return
+    onApply({
+      ...data,
+      segments: data.segments.map((s) => {
+        const next = s.text.replace(pattern, replace)
+        return next === s.text ? s : { ...s, text: next, edited: true }
+      }),
+    })
+    onClose()
+  }
+
+  return (
+    <div role="dialog" className="transcribe-find">
+      <h3>Find &amp; Replace</h3>
+      <input
+        placeholder="Find"
+        value={find}
+        onChange={(e) => setFind(e.target.value)}
+        autoFocus
+      />
+      <input
+        placeholder="Replace with"
+        value={replace}
+        onChange={(e) => setReplace(e.target.value)}
+      />
+      <label>
+        <input type="checkbox" checked={regex} onChange={(e) => setRegex(e.target.checked)} /> Regex
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={caseSensitive}
+          onChange={(e) => setCaseSensitive(e.target.checked)}
+        />{' '}
+        Case sensitive
+      </label>
+      <p style={{ fontSize: 12, color: error ? '#b91c1c' : 'var(--theme-elevation-500)' }}>
+        {error ?? `${matchCount} match${matchCount === 1 ? '' : 'es'}`}
+      </p>
+      <div className="transcribe-find__actions">
+        <button onClick={onClose}>Cancel</button>
+        <button onClick={apply} disabled={!matchCount} className="transcribe-list__cta">
+          Replace all
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/components/Transcribe/Editor/FindReplace.tsx
+++ b/components/Transcribe/Editor/FindReplace.tsx
@@ -8,8 +8,19 @@ interface Props {
   onClose: () => void
 }
 
+const META_CHARS = '.*+?^${}()|[]\\'
 function escapeForRegex(input: string): string {
-  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  let out = ''
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i]
+    out += META_CHARS.includes(ch) ? `\\${ch}` : ch
+  }
+  return out
+}
+
+interface PatternResult {
+  pattern: RegExp | null
+  error: string | null
 }
 
 export default function FindReplace({ data, onApply, onClose }: Props) {
@@ -17,19 +28,20 @@ export default function FindReplace({ data, onApply, onClose }: Props) {
   const [replace, setReplace] = useState('')
   const [regex, setRegex] = useState(false)
   const [caseSensitive, setCaseSensitive] = useState(false)
-  const [error, setError] = useState<string | null>(null)
 
-  const pattern = useMemo<RegExp | null>(() => {
-    if (!find) return null
-    setError(null)
+  const compiled = useMemo<PatternResult>(() => {
+    if (!find) return { pattern: null, error: null }
     const flags = caseSensitive ? 'g' : 'gi'
     try {
-      return regex ? new RegExp(find, flags) : new RegExp(escapeForRegex(find), flags)
+      const p = regex ? new RegExp(find, flags) : new RegExp(escapeForRegex(find), flags)
+      return { pattern: p, error: null }
     } catch (e) {
-      setError(String(e))
-      return null
+      return { pattern: null, error: String(e) }
     }
   }, [find, regex, caseSensitive])
+
+  const pattern = compiled.pattern
+  const error = compiled.error
 
   const matchCount = useMemo(() => {
     if (!pattern) return 0

--- a/components/Transcribe/Editor/Segment.tsx
+++ b/components/Transcribe/Editor/Segment.tsx
@@ -1,0 +1,133 @@
+'use client'
+import { memo, useEffect, useRef } from 'react'
+import type { Segment as SegmentT, Speaker } from '@/lib/transcribe/types'
+
+export interface SegmentProps {
+  seg: SegmentT
+  speakers: Speaker[]
+  isCurrent: boolean
+  currentWordIndex: number | null
+  onSeek: (time: number) => void
+  onTextChange: (id: string, text: string) => void
+  onSpeakerChange: (id: string, speakerId: string) => void
+  onMergeAbove?: (id: string) => void
+  onMergeBelow?: (id: string) => void
+  onSplitAt?: (id: string, wordIndex: number) => void
+}
+
+function fmt(t: number): string {
+  const h = Math.floor(t / 3600)
+  const m = Math.floor((t % 3600) / 60)
+  const s = Math.floor(t % 60)
+  return h > 0
+    ? `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+    : `${m}:${String(s).padStart(2, '0')}`
+}
+
+function speakerLabel(speakers: Speaker[], id: string): string {
+  return speakers.find((sp) => sp.id === id)?.label ?? id
+}
+
+const Segment = memo(function Segment({
+  seg,
+  speakers,
+  isCurrent,
+  currentWordIndex,
+  onSeek,
+  onTextChange,
+  onSpeakerChange,
+  onMergeAbove,
+  onMergeBelow,
+  onSplitAt,
+}: SegmentProps) {
+  const editableRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (
+      editableRef.current &&
+      document.activeElement !== editableRef.current
+    ) {
+      const desired = seg.text
+      if (editableRef.current.textContent !== desired) {
+        editableRef.current.textContent = desired
+      }
+    }
+  }, [seg.text])
+
+  const showWords = !seg.edited && currentWordIndex !== null
+
+  return (
+    <div className={`transcribe-segment${isCurrent ? ' transcribe-segment--current' : ''}`}>
+      <div className="transcribe-segment__head">
+        <select
+          className="transcribe-segment__speaker"
+          value={seg.speakerId}
+          onChange={(e) => onSpeakerChange(seg.id, e.target.value)}
+        >
+          {speakers.map((sp) => (
+            <option key={sp.id} value={sp.id}>
+              {speakerLabel(speakers, sp.id)}
+            </option>
+          ))}
+        </select>
+        <button className="transcribe-segment__time" onClick={() => onSeek(seg.start)}>
+          {fmt(seg.start)}
+        </button>
+        <div className="transcribe-segment__actions">
+          {onMergeAbove && (
+            <button
+              className="transcribe-segment__action"
+              title="Merge with previous segment"
+              onClick={() => onMergeAbove(seg.id)}
+            >
+              ↑ merge
+            </button>
+          )}
+          {onMergeBelow && (
+            <button
+              className="transcribe-segment__action"
+              title="Merge with next segment"
+              onClick={() => onMergeBelow(seg.id)}
+            >
+              ↓ merge
+            </button>
+          )}
+        </div>
+      </div>
+      {showWords ? (
+        <div className="transcribe-segment__words">
+          {seg.words.map((w, i) => (
+            <span
+              key={i}
+              className={`transcribe-segment__word${
+                i === currentWordIndex ? ' transcribe-segment__word--current' : ''
+              }`}
+              onClick={(e) => {
+                if (e.altKey && onSplitAt) onSplitAt(seg.id, i)
+                else onSeek(w.start)
+              }}
+              title={
+                onSplitAt ? 'Click to seek · Alt-click to split here' : 'Click to seek'
+              }
+            >
+              {w.word}
+              {i < seg.words.length - 1 ? ' ' : ''}
+            </span>
+          ))}
+        </div>
+      ) : (
+        <div
+          ref={editableRef}
+          className="transcribe-segment__text"
+          contentEditable
+          suppressContentEditableWarning
+          onBlur={(e) => onTextChange(seg.id, e.currentTarget.textContent ?? '')}
+        >
+          {seg.text}
+        </div>
+      )}
+    </div>
+  )
+})
+
+export default Segment

--- a/components/Transcribe/Editor/SegmentList.tsx
+++ b/components/Transcribe/Editor/SegmentList.tsx
@@ -1,0 +1,99 @@
+'use client'
+import { useEffect, useMemo } from 'react'
+import { List, useListRef, type RowComponentProps } from 'react-window'
+import type { Segment as SegmentT, Speaker } from '@/lib/transcribe/types'
+import Segment from './Segment'
+
+interface Props {
+  segments: SegmentT[]
+  speakers: Speaker[]
+  currentSegmentId: string | null
+  currentWordIndex: number | null
+  onSeek: (time: number) => void
+  onTextChange: (id: string, text: string) => void
+  onSpeakerChange: (id: string, speakerId: string) => void
+  onMergeAbove: (id: string) => void
+  onMergeBelow: (id: string) => void
+  onSplitAt: (id: string, wordIndex: number) => void
+}
+
+interface RowProps {
+  segments: SegmentT[]
+  speakers: Speaker[]
+  currentSegmentId: string | null
+  currentWordIndex: number | null
+  onSeek: (time: number) => void
+  onTextChange: (id: string, text: string) => void
+  onSpeakerChange: (id: string, speakerId: string) => void
+  onMergeAbove: (id: string) => void
+  onMergeBelow: (id: string) => void
+  onSplitAt: (id: string, wordIndex: number) => void
+}
+
+function Row({ index, style, ...row }: RowComponentProps<RowProps>) {
+  const seg = row.segments[index]
+  const isLast = index === row.segments.length - 1
+  return (
+    <div style={style}>
+      <Segment
+        seg={seg}
+        speakers={row.speakers}
+        isCurrent={row.currentSegmentId === seg.id}
+        currentWordIndex={row.currentSegmentId === seg.id ? row.currentWordIndex : null}
+        onSeek={row.onSeek}
+        onTextChange={row.onTextChange}
+        onSpeakerChange={row.onSpeakerChange}
+        onMergeAbove={index > 0 ? row.onMergeAbove : undefined}
+        onMergeBelow={!isLast ? row.onMergeBelow : undefined}
+        onSplitAt={row.onSplitAt}
+      />
+    </div>
+  )
+}
+
+export default function SegmentList(props: Props) {
+  const listRef = useListRef(null)
+
+  const rowProps: RowProps = useMemo(
+    () => ({
+      segments: props.segments,
+      speakers: props.speakers,
+      currentSegmentId: props.currentSegmentId,
+      currentWordIndex: props.currentWordIndex,
+      onSeek: props.onSeek,
+      onTextChange: props.onTextChange,
+      onSpeakerChange: props.onSpeakerChange,
+      onMergeAbove: props.onMergeAbove,
+      onMergeBelow: props.onMergeBelow,
+      onSplitAt: props.onSplitAt,
+    }),
+    [props],
+  )
+
+  useEffect(() => {
+    if (!props.currentSegmentId) return
+    const idx = props.segments.findIndex((s) => s.id === props.currentSegmentId)
+    if (idx >= 0 && listRef.current) {
+      listRef.current.scrollToRow({ index: idx, align: 'smart', behavior: 'smooth' })
+    }
+  }, [props.currentSegmentId, props.segments, listRef])
+
+  const rowHeight = (index: number, _: RowProps): number => {
+    const seg = props.segments[index]
+    if (!seg) return 80
+    const words = seg.words.length
+    return Math.max(72, Math.ceil(words / 12) * 24 + 56)
+  }
+
+  return (
+    <List
+      listRef={listRef}
+      style={{ height: '100%', width: '100%' }}
+      rowCount={props.segments.length}
+      rowComponent={Row}
+      rowProps={rowProps}
+      rowHeight={rowHeight}
+      overscanCount={5}
+    />
+  )
+}

--- a/components/Transcribe/Editor/SpeakerSidebar.tsx
+++ b/components/Transcribe/Editor/SpeakerSidebar.tsx
@@ -1,0 +1,76 @@
+'use client'
+import { useState } from 'react'
+import type { Speaker } from '@/lib/transcribe/types'
+
+interface Props {
+  speakers: Speaker[]
+  segmentCounts: Record<string, number>
+  onRename: (id: string, label: string) => void
+}
+
+export default function SpeakerSidebar({ speakers, segmentCounts, onRename }: Props) {
+  return (
+    <aside className="transcribe-speakers">
+      <h3>Speakers</h3>
+      {speakers.map((sp) => (
+        <SpeakerRow
+          key={sp.id}
+          sp={sp}
+          count={segmentCounts[sp.id] ?? 0}
+          onRename={onRename}
+        />
+      ))}
+    </aside>
+  )
+}
+
+function SpeakerRow({
+  sp,
+  count,
+  onRename,
+}: {
+  sp: Speaker
+  count: number
+  onRename: Props['onRename']
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(sp.label ?? '')
+  const commit = () => {
+    setEditing(false)
+    if (draft !== (sp.label ?? '')) onRename(sp.id, draft)
+  }
+  return (
+    <div className="transcribe-speakers__row">
+      {editing ? (
+        <input
+          autoFocus
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') commit()
+            else if (e.key === 'Escape') {
+              setDraft(sp.label ?? '')
+              setEditing(false)
+            }
+          }}
+          style={{ width: '100%' }}
+        />
+      ) : (
+        <button
+          className="transcribe-speakers__name"
+          onClick={() => {
+            setDraft(sp.label ?? '')
+            setEditing(true)
+          }}
+          title={`Rename ${sp.id}`}
+        >
+          {sp.label || sp.id}
+        </button>
+      )}
+      <div className="transcribe-speakers__count">
+        {count} segment{count === 1 ? '' : 's'}
+      </div>
+    </div>
+  )
+}

--- a/components/Transcribe/JobEditView.tsx
+++ b/components/Transcribe/JobEditView.tsx
@@ -1,0 +1,33 @@
+'use client'
+import { useParams } from 'next/navigation'
+import { useJobStatus } from './hooks/useJobStatus'
+import StatusPanel from './StatusPanel'
+import Editor from './Editor/Editor'
+
+export default function JobEditView() {
+  const params = useParams()
+  // Payload admin route is /admin/collections/audio-jobs/[id]; the id is the
+  // last segment regardless of whether it's a string or array param.
+  const raw = params?.segments
+  const id = Array.isArray(raw) ? raw[raw.length - 1] : (params?.id as string | undefined)
+  const info = useJobStatus(id ?? '')
+  if (!id) return <div style={{ padding: '2rem' }}>Missing job id.</div>
+  if (!info) return <div style={{ padding: '2rem' }}>Loading…</div>
+
+  if (info.status === 'completed') {
+    return (
+      <Editor audioJobId={String(id)} title={info.title ?? ''} kind={info.kind ?? ''} />
+    )
+  }
+  return (
+    <StatusPanel
+      info={info}
+      onRetry={async () => {
+        await fetch(`/api/transcribe/${id}/dispatch`, {
+          method: 'POST',
+          credentials: 'include',
+        })
+      }}
+    />
+  )
+}

--- a/components/Transcribe/JobsListView.tsx
+++ b/components/Transcribe/JobsListView.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+import { useEffect, useState, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import { Gutter } from '@payloadcms/ui'
+import UploadModal from './UploadModal'
+import './transcribe.css'
+
+type Job = {
+  id: number
+  title: string
+  kind: string
+  status: 'queued' | 'dispatching' | 'processing' | 'completed' | 'failed'
+  uploader?: { id: number; firstName?: string; lastName?: string } | number
+  createdAt: string
+  transcribedAt?: string | null
+}
+
+const KINDS = [
+  { value: '', label: 'All kinds' },
+  { value: 'interview', label: 'Interview' },
+  { value: 'meeting', label: 'Meeting' },
+  { value: 'presser', label: 'Press conf' },
+  { value: 'lecture', label: 'Lecture' },
+  { value: 'court', label: 'Court' },
+  { value: 'other', label: 'Other' },
+]
+const STATUSES = [
+  { value: '', label: 'All statuses' },
+  { value: 'queued', label: 'Queued' },
+  { value: 'processing', label: 'Processing' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'failed', label: 'Failed' },
+]
+
+export default function JobsListView() {
+  const router = useRouter()
+  const [jobs, setJobs] = useState<Job[]>([])
+  const [kind, setKind] = useState('')
+  const [status, setStatus] = useState('')
+  const [search, setSearch] = useState('')
+  const [showUpload, setShowUpload] = useState(false)
+  const [loading, setLoading] = useState(true)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    const params = new URLSearchParams()
+    params.set('depth', '1')
+    params.set('limit', '100')
+    params.set('sort', '-createdAt')
+    if (kind) params.append('where[kind][equals]', kind)
+    if (status) params.append('where[status][equals]', status)
+    if (search) params.append('where[title][like]', search)
+    try {
+      const res = await fetch(`/api/audio-jobs?${params}`, { credentials: 'include' })
+      if (res.ok) {
+        const json = (await res.json()) as { docs: Job[] }
+        setJobs(json.docs)
+      }
+    } finally {
+      setLoading(false)
+    }
+  }, [kind, status, search])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  return (
+    <Gutter>
+      <div className="transcribe-list">
+        <div className="transcribe-list__header">
+          <h1>Transcripts</h1>
+          <button className="transcribe-list__cta" onClick={() => setShowUpload(true)}>
+            + Upload audio
+          </button>
+        </div>
+
+        <div className="transcribe-list__filters">
+          <input
+            placeholder="Search title…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <select value={kind} onChange={(e) => setKind(e.target.value)}>
+            {KINDS.map((k) => (
+              <option key={k.value} value={k.value}>
+                {k.label}
+              </option>
+            ))}
+          </select>
+          <select value={status} onChange={(e) => setStatus(e.target.value)}>
+            {STATUSES.map((s) => (
+              <option key={s.value} value={s.value}>
+                {s.label}
+              </option>
+            ))}
+          </select>
+          <a href="/admin/transcribe/search" style={{ marginLeft: 'auto' }}>
+            Search transcripts →
+          </a>
+        </div>
+
+        {loading ? (
+          <p>Loading…</p>
+        ) : jobs.length === 0 ? (
+          <p style={{ color: 'var(--theme-elevation-500)' }}>
+            No transcripts yet. Click &ldquo;+ Upload audio&rdquo; to get started.
+          </p>
+        ) : (
+          <table className="transcribe-list__table">
+            <thead>
+              <tr>
+                <th>Title</th>
+                <th>Kind</th>
+                <th>Status</th>
+                <th>Uploader</th>
+                <th>Created</th>
+              </tr>
+            </thead>
+            <tbody>
+              {jobs.map((j) => {
+                const u = typeof j.uploader === 'object' ? j.uploader : null
+                return (
+                  <tr
+                    key={j.id}
+                    onClick={() => router.push(`/admin/collections/audio-jobs/${j.id}`)}
+                  >
+                    <td>{j.title}</td>
+                    <td>{j.kind}</td>
+                    <td>
+                      <span className={`status-pill status-pill--${j.status}`}>
+                        {j.status}
+                      </span>
+                    </td>
+                    <td>
+                      {u ? `${u.firstName ?? ''} ${u.lastName ?? ''}`.trim() : '—'}
+                    </td>
+                    <td>{new Date(j.createdAt).toLocaleString()}</td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        )}
+
+        {showUpload && (
+          <UploadModal
+            onClose={() => setShowUpload(false)}
+            onCreated={(id) => router.push(`/admin/collections/audio-jobs/${id}`)}
+          />
+        )}
+      </div>
+    </Gutter>
+  )
+}

--- a/components/Transcribe/JobsListView.tsx
+++ b/components/Transcribe/JobsListView.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState, useCallback } from 'react'
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { Gutter } from '@payloadcms/ui'
 import UploadModal from './UploadModal'
@@ -96,9 +97,9 @@ export default function JobsListView() {
               </option>
             ))}
           </select>
-          <a href="/admin/transcribe/search" style={{ marginLeft: 'auto' }}>
+          <Link href="/admin/transcribe/search" style={{ marginLeft: 'auto' }}>
             Search transcripts →
-          </a>
+          </Link>
         </div>
 
         {loading ? (

--- a/components/Transcribe/Search/SearchView.tsx
+++ b/components/Transcribe/Search/SearchView.tsx
@@ -25,18 +25,26 @@ export default function SearchView() {
       setResults([])
       return
     }
-    setLoading(true)
+    let alive = true
     const t = setTimeout(async () => {
-      const res = await fetch(`/api/transcribe/search?q=${encodeURIComponent(q)}`, {
-        credentials: 'include',
-      })
-      if (res.ok) {
-        const j = (await res.json()) as { results: Result[] }
-        setResults(j.results)
+      if (!alive) return
+      setLoading(true)
+      try {
+        const res = await fetch(`/api/transcribe/search?q=${encodeURIComponent(q)}`, {
+          credentials: 'include',
+        })
+        if (alive && res.ok) {
+          const j = (await res.json()) as { results: Result[] }
+          setResults(j.results)
+        }
+      } finally {
+        if (alive) setLoading(false)
       }
-      setLoading(false)
     }, 250)
-    return () => clearTimeout(t)
+    return () => {
+      alive = false
+      clearTimeout(t)
+    }
   }, [q])
 
   return (

--- a/components/Transcribe/Search/SearchView.tsx
+++ b/components/Transcribe/Search/SearchView.tsx
@@ -1,0 +1,68 @@
+'use client'
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import Snippet from './Snippet'
+import type { HighlightRange } from '@/lib/transcribe/highlight'
+import '../transcribe.css'
+
+interface Result {
+  transcript_id: number
+  audio_job_id: number
+  title: string
+  kind: string
+  snippet: string
+  ranges: HighlightRange[]
+  rank: number
+}
+
+export default function SearchView() {
+  const [q, setQ] = useState('')
+  const [results, setResults] = useState<Result[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!q.trim()) {
+      setResults([])
+      return
+    }
+    setLoading(true)
+    const t = setTimeout(async () => {
+      const res = await fetch(`/api/transcribe/search?q=${encodeURIComponent(q)}`, {
+        credentials: 'include',
+      })
+      if (res.ok) {
+        const j = (await res.json()) as { results: Result[] }
+        setResults(j.results)
+      }
+      setLoading(false)
+    }, 250)
+    return () => clearTimeout(t)
+  }, [q])
+
+  return (
+    <div className="transcribe-search">
+      <h1>Search transcripts</h1>
+      <input
+        autoFocus
+        placeholder="words or phrases…"
+        value={q}
+        onChange={(e) => setQ(e.target.value)}
+      />
+      {loading && <p>Searching…</p>}
+      {!loading && q.trim() && results.length === 0 && <p>No results.</p>}
+      <ul className="transcribe-search__list">
+        {results.map((r) => (
+          <li key={r.transcript_id} className="transcribe-search__item">
+            <Link href={`/admin/collections/audio-jobs/${r.audio_job_id}`}>
+              <strong>{r.title}</strong>{' '}
+              <small style={{ color: 'var(--theme-elevation-500)' }}>· {r.kind}</small>
+            </Link>
+            <div className="transcribe-search__snippet">
+              <Snippet text={r.snippet} ranges={r.ranges} />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/components/Transcribe/Search/Snippet.tsx
+++ b/components/Transcribe/Search/Snippet.tsx
@@ -1,0 +1,25 @@
+'use client'
+import type { HighlightRange } from '@/lib/transcribe/highlight'
+import { Fragment } from 'react'
+
+interface Props {
+  text: string
+  ranges: HighlightRange[]
+}
+
+/**
+ * Renders text with `<mark>` highlights driven by character ranges. Pure React
+ * — never injects HTML, so the input cannot smuggle markup.
+ */
+export default function Snippet({ text, ranges }: Props) {
+  if (!ranges.length) return <>{text}</>
+  const out: React.ReactNode[] = []
+  let cursor = 0
+  ranges.forEach((r, i) => {
+    if (r.start > cursor) out.push(<Fragment key={`t-${i}`}>{text.slice(cursor, r.start)}</Fragment>)
+    out.push(<mark key={`m-${i}`}>{text.slice(r.start, r.end)}</mark>)
+    cursor = r.end
+  })
+  if (cursor < text.length) out.push(<Fragment key="tail">{text.slice(cursor)}</Fragment>)
+  return <>{out}</>
+}

--- a/components/Transcribe/StatusPanel.tsx
+++ b/components/Transcribe/StatusPanel.tsx
@@ -1,0 +1,52 @@
+'use client'
+import type { JobStatusInfo } from './hooks/useJobStatus'
+import './transcribe.css'
+
+const COPY: Record<JobStatusInfo['status'], { title: string; sub: string }> = {
+  queued: {
+    title: 'Queued',
+    sub: 'Waiting for the GPU to pick this up. The page will update automatically.',
+  },
+  dispatching: {
+    title: 'Dispatching',
+    sub: 'Sending audio to the transcription service…',
+  },
+  processing: {
+    title: 'Transcribing',
+    sub: 'WhisperX is working on it. Long audio can take 10–30 minutes.',
+  },
+  completed: { title: 'Done', sub: 'Transcript ready.' },
+  failed: { title: 'Failed', sub: 'Something went wrong. See error below.' },
+}
+
+export default function StatusPanel({
+  info,
+  onRetry,
+}: {
+  info: JobStatusInfo
+  onRetry: () => void
+}) {
+  const c = COPY[info.status]
+  const showProgress = info.status !== 'failed' && info.status !== 'completed'
+  const pct = info.progress ?? (info.status === 'processing' ? 50 : 10)
+  return (
+    <div className="transcribe-status">
+      <h2>{c.title}</h2>
+      <p>{c.sub}</p>
+      {showProgress && (
+        <div className="transcribe-status__progress">
+          <div
+            className="transcribe-status__progress-bar"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      )}
+      {info.error && <pre className="transcribe-status__error">{info.error}</pre>}
+      {info.status === 'failed' && (
+        <button className="transcribe-status__retry" onClick={onRetry}>
+          Retry
+        </button>
+      )}
+    </div>
+  )
+}

--- a/components/Transcribe/UploadModal.tsx
+++ b/components/Transcribe/UploadModal.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { useState } from 'react'
+import './transcribe.css'
+
+interface Props {
+  onClose: () => void
+  onCreated: (audioJobId: number) => void
+}
+
+const KINDS = [
+  { value: 'interview', label: 'Interview' },
+  { value: 'meeting', label: 'Meeting' },
+  { value: 'presser', label: 'Press conference' },
+  { value: 'lecture', label: 'Lecture' },
+  { value: 'court', label: 'Court / hearing' },
+  { value: 'other', label: 'Other' },
+]
+
+export default function UploadModal({ onClose, onCreated }: Props) {
+  const [file, setFile] = useState<File | null>(null)
+  const [title, setTitle] = useState('')
+  const [kind, setKind] = useState('interview')
+  const [notes, setNotes] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [progress, setProgress] = useState(0)
+  const [error, setError] = useState<string | null>(null)
+
+  function pickFile(f: File) {
+    setFile(f)
+    if (!title) setTitle(f.name.replace(/\.[^.]+$/, ''))
+  }
+
+  function submit() {
+    if (!file) return
+    setSubmitting(true)
+    setError(null)
+    setProgress(0)
+
+    const form = new FormData()
+    form.append('audio', file)
+    form.append('title', title || file.name)
+    form.append('kind', kind)
+    if (notes) form.append('notes', notes)
+
+    const xhr = new XMLHttpRequest()
+    xhr.upload.onprogress = (e) => {
+      if (e.lengthComputable) setProgress(Math.round((e.loaded / e.total) * 100))
+    }
+    xhr.onload = () => {
+      setSubmitting(false)
+      if (xhr.status === 201) {
+        try {
+          const json = JSON.parse(xhr.responseText)
+          onCreated(json.id)
+        } catch {
+          setError('unexpected response from server')
+        }
+      } else {
+        try {
+          setError(JSON.parse(xhr.responseText).error || `HTTP ${xhr.status}`)
+        } catch {
+          setError(`HTTP ${xhr.status}`)
+        }
+      }
+    }
+    xhr.onerror = () => {
+      setSubmitting(false)
+      setError('Network error')
+    }
+    xhr.open('POST', '/api/transcribe/upload')
+    xhr.withCredentials = true
+    xhr.send(form)
+  }
+
+  return (
+    <div role="dialog" className="transcribe-modal__overlay" onClick={onClose}>
+      <div className="transcribe-modal__panel" onClick={(e) => e.stopPropagation()}>
+        <h2>Upload audio</h2>
+
+        <div
+          className={`transcribe-dropzone${file ? ' transcribe-dropzone--has-file' : ''}`}
+          onClick={() => document.getElementById('audio-file-input')?.click()}
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={(e) => {
+            e.preventDefault()
+            const f = e.dataTransfer.files[0]
+            if (f) pickFile(f)
+          }}
+        >
+          {file ? (
+            <div>
+              <strong>{file.name}</strong>
+              <div style={{ fontSize: 12, opacity: 0.7 }}>
+                {(file.size / 1024 / 1024).toFixed(1)} MB · {file.type || 'audio'}
+              </div>
+            </div>
+          ) : (
+            <>Drop audio file here or click to choose. Max 6 hours.</>
+          )}
+        </div>
+        <input
+          id="audio-file-input"
+          type="file"
+          accept="audio/*,.m4a,.mp3,.wav,.opus,.ogg,.flac,.webm"
+          style={{ display: 'none' }}
+          onChange={(e) => {
+            const f = e.target.files?.[0]
+            if (f) pickFile(f)
+          }}
+        />
+
+        <label className="transcribe-modal__field">
+          Title
+          <input value={title} onChange={(e) => setTitle(e.target.value)} />
+        </label>
+        <label className="transcribe-modal__field">
+          Kind
+          <select value={kind} onChange={(e) => setKind(e.target.value)}>
+            {KINDS.map((k) => (
+              <option key={k.value} value={k.value}>
+                {k.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="transcribe-modal__field">
+          Notes
+          <textarea value={notes} onChange={(e) => setNotes(e.target.value)} rows={3} />
+        </label>
+
+        {submitting && (
+          <div style={{ margin: '0.5rem 0', fontSize: 13 }}>
+            Uploading… {progress}%
+            <div className="transcribe-progress-track">
+              <div
+                className="transcribe-progress-bar"
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+          </div>
+        )}
+        {error && <div className="transcribe-error">{error}</div>}
+
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+          <button onClick={onClose} disabled={submitting}>
+            Cancel
+          </button>
+          <button
+            onClick={submit}
+            disabled={!file || submitting}
+            className="transcribe-list__cta"
+          >
+            Upload
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/Transcribe/hooks/useAudioPlayback.ts
+++ b/components/Transcribe/hooks/useAudioPlayback.ts
@@ -1,0 +1,59 @@
+'use client'
+import { useEffect, useState, RefObject } from 'react'
+import type { TranscriptData } from '@/lib/transcribe/types'
+
+export interface CurrentPosition {
+  segmentId: string | null
+  wordIndex: number | null
+  time: number
+}
+
+export function useAudioPlayback(
+  audioRef: RefObject<HTMLAudioElement | null>,
+  data: TranscriptData | null,
+): CurrentPosition {
+  const [pos, setPos] = useState<CurrentPosition>({
+    segmentId: null,
+    wordIndex: null,
+    time: 0,
+  })
+
+  useEffect(() => {
+    const el = audioRef.current
+    if (!el || !data) return
+    const onTime = () => {
+      const t = el.currentTime
+      const segs = data.segments
+      let lo = 0
+      let hi = segs.length - 1
+      let segIdx = -1
+      while (lo <= hi) {
+        const mid = (lo + hi) >> 1
+        const s = segs[mid]
+        if (t < s.start) hi = mid - 1
+        else if (t > s.end) lo = mid + 1
+        else {
+          segIdx = mid
+          break
+        }
+      }
+      if (segIdx === -1) {
+        setPos({ segmentId: null, wordIndex: null, time: t })
+        return
+      }
+      const seg = segs[segIdx]
+      let wi = -1
+      for (let i = 0; i < seg.words.length; i++) {
+        if (t >= seg.words[i].start && t <= seg.words[i].end) {
+          wi = i
+          break
+        }
+      }
+      setPos({ segmentId: seg.id, wordIndex: wi >= 0 ? wi : null, time: t })
+    }
+    el.addEventListener('timeupdate', onTime)
+    return () => el.removeEventListener('timeupdate', onTime)
+  }, [audioRef, data])
+
+  return pos
+}

--- a/components/Transcribe/hooks/useJobStatus.ts
+++ b/components/Transcribe/hooks/useJobStatus.ts
@@ -1,0 +1,39 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+export type JobStatusInfo = {
+  id: string | number
+  status: 'queued' | 'dispatching' | 'processing' | 'completed' | 'failed'
+  progress?: number
+  error?: string | null
+  title?: string
+  kind?: string
+  transcribedAt?: string | null
+}
+
+export function useJobStatus(id: string | number, intervalMs = 5000): JobStatusInfo | null {
+  const [info, setInfo] = useState<JobStatusInfo | null>(null)
+  useEffect(() => {
+    let alive = true
+    let timer: ReturnType<typeof setTimeout> | null = null
+    const tick = async () => {
+      try {
+        const res = await fetch(`/api/transcribe/${id}`, { credentials: 'include' })
+        if (alive && res.ok) {
+          const j = (await res.json()) as JobStatusInfo
+          setInfo(j)
+          if (j.status === 'completed' || j.status === 'failed') return
+        }
+      } catch {
+        /* ignore */
+      }
+      if (alive) timer = setTimeout(tick, intervalMs)
+    }
+    void tick()
+    return () => {
+      alive = false
+      if (timer) clearTimeout(timer)
+    }
+  }, [id, intervalMs])
+  return info
+}

--- a/components/Transcribe/hooks/useTranscript.ts
+++ b/components/Transcribe/hooks/useTranscript.ts
@@ -1,0 +1,69 @@
+'use client'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { TranscriptData } from '@/lib/transcribe/types'
+
+export type SaveState = 'idle' | 'dirty' | 'saving' | 'saved' | 'error'
+
+export function useTranscript(audioJobId: string) {
+  const [data, setData] = useState<TranscriptData | null>(null)
+  const [saveState, setSaveState] = useState<SaveState>('idle')
+  const dirtyRef = useRef<TranscriptData | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    let alive = true
+    void (async () => {
+      const res = await fetch(`/api/transcribe/${audioJobId}/transcript`, {
+        credentials: 'include',
+      })
+      if (alive && res.ok) {
+        const j = (await res.json()) as { data: TranscriptData }
+        setData(j.data)
+      }
+    })()
+    return () => {
+      alive = false
+    }
+  }, [audioJobId])
+
+  const flush = useCallback(async () => {
+    if (!dirtyRef.current) return
+    const payload = dirtyRef.current
+    dirtyRef.current = null
+    setSaveState('saving')
+    try {
+      const res = await fetch(`/api/transcribe/${audioJobId}/transcript`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data: payload }),
+      })
+      setSaveState(res.ok ? 'saved' : 'error')
+    } catch {
+      setSaveState('error')
+    }
+  }, [audioJobId])
+
+  const update = useCallback(
+    (next: TranscriptData) => {
+      setData(next)
+      dirtyRef.current = next
+      setSaveState('dirty')
+      if (timerRef.current) clearTimeout(timerRef.current)
+      timerRef.current = setTimeout(() => {
+        void flush()
+      }, 2000)
+    },
+    [flush],
+  )
+
+  const forceSave = useCallback(async () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    await flush()
+  }, [flush])
+
+  return { data, update, forceSave, saveState }
+}

--- a/components/Transcribe/transcribe.css
+++ b/components/Transcribe/transcribe.css
@@ -1,0 +1,398 @@
+.transcribe-list {
+  padding: 1.5rem;
+}
+.transcribe-list__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+.transcribe-list__cta {
+  background: #16a34a;
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+}
+.transcribe-list__cta:hover {
+  filter: brightness(0.95);
+}
+.transcribe-list__filters {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.transcribe-list__filters input,
+.transcribe-list__filters select {
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--theme-elevation-200, #ccc);
+  border-radius: 4px;
+  background: var(--theme-elevation-0, white);
+  color: var(--theme-text, inherit);
+}
+.transcribe-list__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.transcribe-list__table th,
+.transcribe-list__table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--theme-elevation-100, #eee);
+}
+.transcribe-list__table tr {
+  cursor: pointer;
+}
+.transcribe-list__table tbody tr:hover {
+  background: var(--theme-elevation-50, #f8f8f8);
+}
+.status-pill {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+.status-pill--queued,
+.status-pill--dispatching {
+  background: #e5e7eb;
+  color: #374151;
+}
+.status-pill--processing {
+  background: #dbeafe;
+  color: #1e40af;
+}
+.status-pill--completed {
+  background: #dcfce7;
+  color: #166534;
+}
+.status-pill--failed {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.transcribe-modal__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: grid;
+  place-items: center;
+  z-index: 1000;
+}
+.transcribe-modal__panel {
+  background: var(--theme-elevation-0, white);
+  color: var(--theme-text, inherit);
+  padding: 1.5rem;
+  border-radius: 8px;
+  width: 480px;
+  max-width: 90vw;
+}
+.transcribe-modal__panel h2 {
+  margin-top: 0;
+}
+.transcribe-modal__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0.75rem 0;
+}
+.transcribe-modal__field input,
+.transcribe-modal__field select,
+.transcribe-modal__field textarea {
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--theme-elevation-200, #ccc);
+  border-radius: 4px;
+  background: var(--theme-elevation-0, white);
+  color: var(--theme-text, inherit);
+}
+.transcribe-dropzone {
+  border: 2px dashed var(--theme-elevation-200, #ccc);
+  border-radius: 8px;
+  padding: 1.5rem;
+  text-align: center;
+  cursor: pointer;
+  margin-bottom: 0.5rem;
+}
+.transcribe-dropzone--has-file {
+  border-color: #16a34a;
+}
+.transcribe-progress-track {
+  height: 4px;
+  background: var(--theme-elevation-100, #eee);
+  border-radius: 2px;
+  margin-top: 4px;
+}
+.transcribe-progress-bar {
+  height: 100%;
+  background: #16a34a;
+  border-radius: 2px;
+}
+.transcribe-error {
+  color: #b91c1c;
+  margin: 0.5rem 0;
+  font-size: 13px;
+}
+
+.transcribe-status {
+  padding: 2rem;
+  text-align: center;
+  max-width: 520px;
+  margin: 0 auto;
+}
+.transcribe-status__progress {
+  width: 240px;
+  height: 4px;
+  background: var(--theme-elevation-100, #eee);
+  border-radius: 2px;
+  margin: 1rem auto;
+}
+.transcribe-status__progress-bar {
+  height: 100%;
+  background: #1e40af;
+  border-radius: 2px;
+  transition: width 0.3s;
+}
+.transcribe-status__error {
+  background: var(--theme-elevation-100, #fee);
+  padding: 1rem;
+  border-radius: 4px;
+  text-align: left;
+  white-space: pre-wrap;
+  font-size: 13px;
+}
+.transcribe-status__retry {
+  padding: 0.5rem 1rem;
+  background: #16a34a;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.transcribe-editor {
+  display: grid;
+  grid-template-rows: auto auto 1fr;
+  height: calc(100vh - 60px);
+  overflow: hidden;
+}
+.transcribe-editor__header {
+  padding: 0.75rem 1.5rem;
+  border-bottom: 1px solid var(--theme-elevation-100, #eee);
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.transcribe-editor__header h2 {
+  margin: 0;
+  font-size: 18px;
+}
+.transcribe-editor__save {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--theme-elevation-500, #666);
+}
+.transcribe-editor__save--error {
+  color: #b91c1c;
+}
+.transcribe-editor__player {
+  padding: 0.5rem 1.5rem;
+  border-bottom: 1px solid var(--theme-elevation-100, #eee);
+}
+.transcribe-editor__body {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  overflow: hidden;
+}
+
+.transcribe-speakers {
+  border-right: 1px solid var(--theme-elevation-100, #eee);
+  padding: 1rem;
+  overflow-y: auto;
+}
+.transcribe-speakers h3 {
+  margin: 0 0 0.5rem;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--theme-elevation-500, #666);
+}
+.transcribe-speakers__row {
+  margin-bottom: 0.75rem;
+}
+.transcribe-speakers__name {
+  background: none;
+  border: none;
+  text-align: left;
+  padding: 0;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+  color: inherit;
+}
+.transcribe-speakers__count {
+  font-size: 12px;
+  color: var(--theme-elevation-500, #666);
+}
+
+.transcribe-segment-list {
+  padding: 0 1.5rem;
+  overflow: hidden;
+}
+.transcribe-segment {
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--theme-elevation-100, #eee);
+}
+.transcribe-segment--current {
+  background: var(--theme-elevation-50, #f8f8f8);
+}
+.transcribe-segment__head {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 4px;
+  font-size: 12px;
+}
+.transcribe-segment__speaker {
+  font-weight: 600;
+  padding: 0.125rem 0.25rem;
+}
+.transcribe-segment__time {
+  background: none;
+  border: none;
+  color: var(--theme-elevation-500, #666);
+  cursor: pointer;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+.transcribe-segment__actions {
+  margin-left: auto;
+  display: flex;
+  gap: 4px;
+}
+.transcribe-segment__action {
+  background: none;
+  border: 1px solid var(--theme-elevation-200, #ccc);
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 11px;
+  cursor: pointer;
+  color: var(--theme-elevation-500, #666);
+}
+.transcribe-segment__action:hover {
+  color: var(--theme-text, inherit);
+  border-color: var(--theme-elevation-400, #999);
+}
+.transcribe-segment__text {
+  outline: none;
+  line-height: 1.5;
+  font-size: 15px;
+  min-height: 1.5em;
+}
+.transcribe-segment__words {
+  line-height: 1.5;
+  font-size: 15px;
+}
+.transcribe-segment__word {
+  cursor: pointer;
+  padding: 0 1px;
+  border-radius: 2px;
+}
+.transcribe-segment__word--current {
+  background: #fef08a;
+  color: #92400e;
+}
+
+.transcribe-find {
+  position: fixed;
+  top: 80px;
+  right: 20px;
+  background: var(--theme-elevation-0, white);
+  color: var(--theme-text, inherit);
+  border: 1px solid var(--theme-elevation-200, #ccc);
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  z-index: 100;
+  width: 320px;
+}
+.transcribe-find h3 {
+  margin: 0 0 0.5rem;
+  font-size: 14px;
+}
+.transcribe-find input[type='text'],
+.transcribe-find input:not([type]) {
+  width: 100%;
+  margin-bottom: 8px;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--theme-elevation-200, #ccc);
+  border-radius: 4px;
+}
+.transcribe-find label {
+  display: block;
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+.transcribe-find__actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+.transcribe-export {
+  display: inline-flex;
+  gap: 4px;
+}
+.transcribe-export button {
+  padding: 0.25rem 0.6rem;
+  font-size: 12px;
+  border: 1px solid var(--theme-elevation-200, #ccc);
+  border-radius: 4px;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+}
+.transcribe-export button:hover {
+  background: var(--theme-elevation-50, #f8f8f8);
+}
+
+.transcribe-search {
+  padding: 2rem;
+  max-width: 900px;
+  margin: 0 auto;
+}
+.transcribe-search input {
+  width: 100%;
+  padding: 0.75rem;
+  font-size: 16px;
+  border: 1px solid var(--theme-elevation-200, #ccc);
+  border-radius: 6px;
+  background: var(--theme-elevation-0, white);
+  color: var(--theme-text, inherit);
+}
+.transcribe-search__list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+}
+.transcribe-search__item {
+  padding: 1rem 0;
+  border-bottom: 1px solid var(--theme-elevation-100, #eee);
+}
+.transcribe-search__snippet {
+  margin-top: 4px;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.transcribe-search__snippet mark {
+  background: #fef08a;
+  color: inherit;
+  padding: 0 2px;
+  border-radius: 2px;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: polymer-dev-db
     # Local dev only: bump max_connections so `next build` (which parallelizes
     # prerender across all CPU cores) doesn't exhaust the default 100 cap.
-    command: postgres -c max_connections=400
+    command: postgres -c max_connections=1000
     environment:
       POSTGRES_DB: polymer_dev
       POSTGRES_USER: polymer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,9 @@ services:
   db:
     image: postgres:16
     container_name: polymer-dev-db
+    # Local dev only: bump max_connections so `next build` (which parallelizes
+    # prerender across all CPU cores) doesn't exhaust the default 100 cap.
+    command: postgres -c max_connections=400
     environment:
       POSTGRES_DB: polymer_dev
       POSTGRES_USER: polymer

--- a/docs/superpowers/plans/2026-04-28-audio-transcription.md
+++ b/docs/superpowers/plans/2026-04-28-audio-transcription.md
@@ -1,0 +1,725 @@
+# Audio Transcription Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add audio upload + async high-accuracy transcription with speaker diarization, accessible via a fully-custom Payload admin UI for writers/editors/EIC/admins.
+
+**Architecture:** Polymer (Next.js + Payload) holds 3 new collections (`audioFiles`, `audioJobs`, `transcripts`), receives uploads, transcodes to opus 32 kbps mono 16 kHz, dispatches over a Cloudflare Tunnel + CF Access service-token to a separate FastAPI service running WhisperX on a homelab RTX 4070. The GPU service POSTs an HMAC-signed webhook back. The custom Payload admin UI handles upload, status polling, transcript editing, export, and Postgres FTS search.
+
+**Tech Stack:** Next.js 16, React 19, Payload 3.80, PostgreSQL, ffmpeg/ffprobe, WhisperX (separate service), Cloudflare Tunnel + Access.
+
+**Spec:** `docs/superpowers/specs/2026-04-28-audio-transcription-design.md`
+**GPU service prompt:** `docs/superpowers/specs/2026-04-28-polymer-transcribe-prompt.md`
+
+---
+
+## File Map
+
+**New (polymer side):**
+
+```
+collections/{AudioFiles,AudioJobs,Transcripts}.ts
+migrations/20260428_100000_add_audio_transcription.ts
+lib/transcribe/{ffmpeg,hmac,dispatch,types,segments,exporters,config,highlight}.ts
+app/api/transcribe/{upload,webhook,search}/route.ts
+app/api/transcribe/[id]/{route,transcript/route,dispatch/route,audio/route}.ts
+app/(payload)/admin/transcribe/search/page.tsx
+components/Transcribe/{JobsListView,UploadModal,JobEditView,StatusPanel}.tsx
+components/Transcribe/Editor/{Editor,AudioPlayer,SpeakerSidebar,SegmentList,Segment,FindReplace,ExportMenu}.tsx
+components/Transcribe/Search/{SearchView,Snippet}.tsx
+components/Transcribe/hooks/{useTranscript,useAudioPlayback,useJobStatus}.ts
+components/Transcribe/transcribe.css
+tests/lib/transcribe/{hmac,segments,exporters,highlight}.test.ts
+```
+
+**Modified:**
+`payload.config.ts`, `migrations/index.ts`, `scripts/run_deploy_sql_migrations.sh`, `scripts/generate-env.js`, `package.json`, `payload-types.ts` (auto), `.github/workflows/deploy.yml`.
+
+---
+
+## Phase 1 — Foundation
+
+### Task 1: AudioFiles upload collection
+
+**Files:** create `collections/AudioFiles.ts`; modify `payload.config.ts`.
+
+Implement an upload-enabled collection with slug `audio-files`:
+- `staticDir`: `process.env.AUDIO_DIR || '/var/www/polymer-media/audio'`.
+- `mimeTypes`: `audio/mpeg`, `audio/mp4`, `audio/x-m4a`, `audio/wav`, `audio/x-wav`, `audio/ogg`, `audio/flac`, `audio/webm`, `audio/opus`.
+- Fields: `durationSeconds` (number, readonly), `uploader` (relationship → users, sidebar, readonly).
+- Access: read = uploader OR staff (admin/eic/editor); create = any of admin/eic/editor/writer; update = false; delete = admin only.
+- `beforeChange` hook (operation === 'create'): set `data.uploader = req.user.id`.
+- `admin.hidden`: hide collection from sidebar except for admins.
+
+Follow `collections/DeviceTokens.ts` for the role-check shape using a `UserWithRoles` cast.
+
+Register in `payload.config.ts` by adding the import and appending to the `collections: [...]` array.
+
+- [ ] Step 1: Write the collection file.
+- [ ] Step 2: Register in `payload.config.ts`.
+- [ ] Step 3: `git add collections/AudioFiles.ts payload.config.ts && git commit -m "feat(transcribe): add AudioFiles upload collection"`.
+
+---
+
+### Task 2: AudioJobs collection
+
+**Files:** create `collections/AudioJobs.ts`; modify `payload.config.ts`.
+
+Slug `audio-jobs`, label "Transcript / Transcripts", group "Newsroom".
+
+Fields:
+| name | type | notes |
+|---|---|---|
+| `title` | text | required |
+| `kind` | select | required, default `interview`; options: interview / meeting / presser / lecture / court / other |
+| `notes` | textarea | |
+| `audioFile` | relationship → audio-files | required, readonly |
+| `uploader` | relationship → users | sidebar, readonly |
+| `status` | select | required, default `queued`; options: queued / dispatching / processing / completed / failed; readonly, sidebar |
+| `externalJobId` | text | hidden, readonly |
+| `callbackSecret` | text | hidden, readonly |
+| `progress` | number | hidden, readonly |
+| `dispatchAttempts` | number | default 0, hidden |
+| `error` | textarea | readonly, condition: only when present |
+| `transcribedAt` | date | readonly, hidden |
+
+Access:
+- `read`: uploader OR staff (admin/eic/editor) → use Payload `where` filter for non-staff.
+- `create`: writer/editor/eic/admin.
+- `update` / `delete`: uploader or admin.
+
+`beforeChange` hook on create sets `uploader` from `req.user.id` if not already set.
+
+Custom views are wired in Tasks 12 & 14, leave `admin.components.views` empty for now.
+
+- [ ] Step 1: Write file.
+- [ ] Step 2: Register in `payload.config.ts`.
+- [ ] Step 3: `git add collections/AudioJobs.ts payload.config.ts && git commit -m "feat(transcribe): add AudioJobs collection with kind/status/dispatch fields"`.
+
+---
+
+### Task 3: Transcripts collection
+
+**Files:** create `collections/Transcripts.ts`; modify `payload.config.ts`.
+
+Slug `transcripts`. Hidden from sidebar for non-admins.
+
+Fields:
+- `audioJob` — relationship → audio-jobs, required, unique, readonly.
+- `data` — `json`, required.
+- `searchableText` — `textarea`, hidden.
+- `editedAt` — date, readonly.
+- `editedBy` — relationship → users, readonly.
+
+Access: read for any authenticated staff (we enforce ownership at the route layer because Payload access can't easily join across collections); update by any authenticated user (route enforces ownership); delete admin-only.
+
+- [ ] Step 1: Write file.
+- [ ] Step 2: Register in `payload.config.ts`.
+- [ ] Step 3: `git add collections/Transcripts.ts payload.config.ts && git commit -m "feat(transcribe): add Transcripts collection with json data + searchable text"`.
+
+---
+
+### Task 4: Migration (TypeScript) + SQL deploy script entry
+
+**Files:** create `migrations/20260428_100000_add_audio_transcription.ts`; modify `migrations/index.ts`; modify `scripts/run_deploy_sql_migrations.sh`.
+
+The migration creates three tables and two enums, plus the locked-documents-rels columns Payload requires.
+
+DDL (used in both the TS migration's `up()` body and the appended SQL block):
+
+```sql
+DO $$ BEGIN
+  CREATE TYPE "public"."enum_audio_jobs_kind" AS ENUM('interview','meeting','presser','lecture','court','other');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  CREATE TYPE "public"."enum_audio_jobs_status" AS ENUM('queued','dispatching','processing','completed','failed');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS "audio_files" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "duration_seconds" numeric,
+  "uploader_id" integer,
+  "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  "url" varchar,
+  "thumbnail_u_r_l" varchar,
+  "filename" varchar,
+  "mime_type" varchar,
+  "filesize" numeric,
+  "width" numeric,
+  "height" numeric,
+  "focal_x" numeric,
+  "focal_y" numeric
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "audio_files_filename_idx" ON "audio_files" USING btree ("filename");
+CREATE INDEX IF NOT EXISTS "audio_files_uploader_idx" ON "audio_files" USING btree ("uploader_id");
+CREATE INDEX IF NOT EXISTS "audio_files_created_at_idx" ON "audio_files" USING btree ("created_at");
+DO $$ BEGIN
+  ALTER TABLE "audio_files" ADD CONSTRAINT "audio_files_uploader_id_users_id_fk"
+    FOREIGN KEY ("uploader_id") REFERENCES "public"."users"("id") ON DELETE SET NULL;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS "audio_jobs" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "title" varchar NOT NULL,
+  "kind" "public"."enum_audio_jobs_kind" NOT NULL DEFAULT 'interview',
+  "notes" varchar,
+  "audio_file_id" integer NOT NULL,
+  "uploader_id" integer,
+  "status" "public"."enum_audio_jobs_status" NOT NULL DEFAULT 'queued',
+  "external_job_id" varchar,
+  "callback_secret" varchar,
+  "progress" numeric,
+  "dispatch_attempts" numeric DEFAULT 0,
+  "error" varchar,
+  "transcribed_at" timestamp(3) with time zone,
+  "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+);
+CREATE INDEX IF NOT EXISTS "audio_jobs_status_idx" ON "audio_jobs" USING btree ("status");
+CREATE INDEX IF NOT EXISTS "audio_jobs_uploader_idx" ON "audio_jobs" USING btree ("uploader_id");
+CREATE INDEX IF NOT EXISTS "audio_jobs_created_at_idx" ON "audio_jobs" USING btree ("created_at");
+CREATE UNIQUE INDEX IF NOT EXISTS "audio_jobs_external_job_id_idx" ON "audio_jobs" USING btree ("external_job_id") WHERE "external_job_id" IS NOT NULL;
+DO $$ BEGIN
+  ALTER TABLE "audio_jobs" ADD CONSTRAINT "audio_jobs_audio_file_id_audio_files_id_fk"
+    FOREIGN KEY ("audio_file_id") REFERENCES "public"."audio_files"("id") ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE "audio_jobs" ADD CONSTRAINT "audio_jobs_uploader_id_users_id_fk"
+    FOREIGN KEY ("uploader_id") REFERENCES "public"."users"("id") ON DELETE SET NULL;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS "transcripts" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "audio_job_id" integer NOT NULL,
+  "data" jsonb NOT NULL,
+  "searchable_text" text,
+  "edited_at" timestamp(3) with time zone,
+  "edited_by_id" integer,
+  "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "transcripts_audio_job_idx" ON "transcripts" USING btree ("audio_job_id");
+CREATE INDEX IF NOT EXISTS "transcripts_searchable_text_fts_idx" ON "transcripts"
+  USING gin (to_tsvector('english', coalesce("searchable_text", '')));
+DO $$ BEGIN
+  ALTER TABLE "transcripts" ADD CONSTRAINT "transcripts_audio_job_id_audio_jobs_id_fk"
+    FOREIGN KEY ("audio_job_id") REFERENCES "public"."audio_jobs"("id") ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE "transcripts" ADD CONSTRAINT "transcripts_edited_by_id_users_id_fk"
+    FOREIGN KEY ("edited_by_id") REFERENCES "public"."users"("id") ON DELETE SET NULL;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+ALTER TABLE "payload_locked_documents_rels" ADD COLUMN IF NOT EXISTS "audio_files_id" integer;
+ALTER TABLE "payload_locked_documents_rels" ADD COLUMN IF NOT EXISTS "audio_jobs_id" integer;
+ALTER TABLE "payload_locked_documents_rels" ADD COLUMN IF NOT EXISTS "transcripts_id" integer;
+DO $$ BEGIN
+  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_audio_files_fk"
+    FOREIGN KEY ("audio_files_id") REFERENCES "public"."audio_files"("id") ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_audio_jobs_fk"
+    FOREIGN KEY ("audio_jobs_id") REFERENCES "public"."audio_jobs"("id") ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_transcripts_fk"
+    FOREIGN KEY ("transcripts_id") REFERENCES "public"."transcripts"("id") ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_audio_files_id_idx" ON "payload_locked_documents_rels" ("audio_files_id");
+CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_audio_jobs_id_idx" ON "payload_locked_documents_rels" ("audio_jobs_id");
+CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_transcripts_id_idx" ON "payload_locked_documents_rels" ("transcripts_id");
+```
+
+The TypeScript migration follows `migrations/20260424_020000_add_device_tokens.ts` for shape: `up({ db })` runs `db.execute(sql\`<DDL>\`)`; `down()` reverses.
+
+`migrations/index.ts`: import the new module and add to the exported `migrations` array (matches existing pattern).
+
+`scripts/run_deploy_sql_migrations.sh`: append the same DDL above into the heredoc, and add `('20260428_100000_add_audio_transcription', <next-batch>, NOW(), NOW())` to the tracking insert list (next batch = current max + 1; check the file).
+
+- [ ] Step 1: Write `migrations/20260428_100000_add_audio_transcription.ts`.
+- [ ] Step 2: Register in `migrations/index.ts`.
+- [ ] Step 3: Append to `scripts/run_deploy_sql_migrations.sh`.
+- [ ] Step 4: `pnpm db:fresh` — expect clean rebuild.
+- [ ] Step 5: `pnpm generate:types` — expect `payload-types.ts` updated.
+- [ ] Step 6: Commit migration files + payload-types.
+
+---
+
+## Phase 2 — Transport
+
+### Task 5: Types + env config
+
+**Files:** create `lib/transcribe/types.ts`, `lib/transcribe/config.ts`; modify `scripts/generate-env.js`.
+
+`types.ts` exports:
+- `Speaker`: `{ id: string; label: string | null }`
+- `Word`: `{ word: string; start: number; end: number; score?: number }`
+- `Segment`: `{ id: string; speakerId: string; start: number; end: number; text: string; words: Word[]; edited?: boolean }`
+- `TranscriptData`: `{ language: string; duration: number; model: string; speakers: Speaker[]; segments: Segment[] }`
+- `TranscribeWebhookBody`: webhook payload shape (job_id, status, metadata.audioJobId, result with snake_case speaker_id, error)
+
+`config.ts` exports `getTranscribeConfig()` returning either `{ configured: false }` or `{ configured: true, url, apiKey, cfClientId, cfClientSecret, publicBaseUrl }` from env vars `TRANSCRIBE_API_URL`, `TRANSCRIBE_API_KEY`, `TRANSCRIBE_CF_ACCESS_CLIENT_ID`, `TRANSCRIBE_CF_ACCESS_CLIENT_SECRET`, `TRANSCRIBE_PUBLIC_BASE_URL` (fallback `NEXT_PUBLIC_SITE_URL`). Strip trailing slashes.
+
+`generate-env.js`: append stub entries for the five `TRANSCRIBE_*` vars and `AUDIO_DIR=/var/www/polymer-media/audio`.
+
+- [ ] Step 1–3: write files, modify generate-env.js.
+- [ ] Step 4: commit.
+
+---
+
+### Task 6: HMAC sign/verify util + tests
+
+**Files:** create `lib/transcribe/hmac.ts`, `tests/lib/transcribe/hmac.test.ts`; modify `package.json` (add `vitest` devDep + `test:unit` script).
+
+`hmac.ts` exports two functions using `node:crypto`:
+- `signBody(body, secret)`: returns hex digest of HMAC-SHA256(body, secret) via `createHmac`.
+- `verifySignature(body, header, secret)`: strips optional `sha256=` prefix; uses `timingSafeEqual` on equal-length hex buffers; returns false on null/undefined/malformed.
+
+Tests cover:
+1. signBody is deterministic (assert exact known digest for `signBody('hello', 'secret')`).
+2. verifySignature accepts `sha256=` prefix and bare hex.
+3. Tampered body fails.
+4. Wrong secret fails.
+5. Null/undefined header fails.
+6. Malformed hex fails.
+
+- [ ] Step 1: `pnpm add -D vitest` and add `"test:unit": "vitest run"` to scripts.
+- [ ] Step 2–4: write hmac.ts, tests, run `pnpm test:unit`.
+- [ ] Step 5: commit.
+
+---
+
+### Task 7: ffmpeg / ffprobe wrappers
+
+**Files:** create `lib/transcribe/ffmpeg.ts`.
+
+Two async functions, both shelling out via Node's `spawn` (from `node:child_process`) with array args — never construct a shell command string and never use the unsafe shell-execution variants. The array form passes args directly to the binary, so it is shell-injection safe.
+
+1. `ffprobe(filePath: string): Promise<{ durationSeconds: number; hasAudio: boolean }>` — run `ffprobe` with arguments `['-v', 'error', '-print_format', 'json', '-show_format', '-show_streams', filePath]`. Buffer stdout, parse JSON, return `{ durationSeconds: Number(format.duration ?? 0), hasAudio: streams.some(s => s.codec_type === 'audio') }`. Reject with stderr on non-zero exit.
+
+2. `transcodeToOpus(input: string, output: string): Promise<void>` — run `ffmpeg` with arguments `['-y', '-i', input, '-vn', '-ac', '1', '-ar', '16000', '-c:a', 'libopus', '-b:a', '32k', '-application', 'voip', output]`. Reject with last 2 KB of stderr on non-zero exit; resolve on zero.
+
+- [ ] Step 1: write the file.
+- [ ] Step 2 (manual smoke if any sample file exists; else covered by Task 9 integration).
+- [ ] Step 3: commit.
+
+---
+
+### Task 8: Dispatch helper
+
+**Files:** create `lib/transcribe/dispatch.ts`.
+
+Export `dispatchToTranscribeApi({ audioPath, audioFilename, audioMimeType, audioJobId, callbackSecret })` returning `{ externalJobId, queuePosition }`.
+
+Behavior:
+- Read config via `getTranscribeConfig()`. Throw if not configured.
+- Build `callback_url = ${publicBaseUrl}/api/transcribe/webhook`.
+- Stream file from disk → `Blob` (use `Response` constructor on `Readable.toWeb(createReadStream(path))` then `.blob()`).
+- Build `FormData` with: `audio` (Blob with filename), `callback_url`, `callback_secret`, `job_metadata: JSON.stringify({ audioJobId })`.
+- POST `${url}/v1/jobs` with headers `Authorization: Bearer ${apiKey}`, `CF-Access-Client-Id: ${cfClientId}`, `CF-Access-Client-Secret: ${cfClientSecret}`. Use `AbortSignal.timeout(10 * 60 * 1000)`.
+- On non-OK: throw with status + first 500 chars of body. On OK: parse `{ job_id, queue_position }` and return.
+
+- [ ] Step 1: write file.
+- [ ] Step 2: commit.
+
+---
+
+### Task 9: Upload route
+
+**Files:** create `app/api/transcribe/upload/route.ts`.
+
+POST handler:
+1. Auth via `payload.auth({ headers })`. 401 on no user. 403 if no staff role.
+2. Read `formData()`. Require `audio` instanceof File. Read `title`, `kind`, `notes` form fields.
+3. Buffer the file to a temp path under `os.tmpdir()`.
+4. `ffprobe` it; reject 415 if no audio stream, 400 if duration > 6 hours.
+5. Create `audio-files` record via `payload.create({ collection: 'audio-files', file: { data, mimetype, name, size }, data: { durationSeconds, uploader: user.id } })`.
+6. Generate `callbackSecret = randomBytes(32).toString('hex')`.
+7. Create `audio-jobs` record with `status: 'queued'`, the audioFile id, uploader, title/kind/notes, callbackSecret.
+8. Return 201 `{ id: job.id, status: 'queued' }`.
+9. Fire `dispatchInBackground(...)` with `void` (don't await). Cleanup temp file in `finally`.
+
+`dispatchInBackground({ audioJobId, audioFilePath, audioFilename, audioMimeType, callbackSecret })`:
+- Get config; if not configured, mark job failed with explanatory error and return.
+- Set status `dispatching`. Transcode to a sibling `.opus` file. Call `dispatchToTranscribeApi`. Set status `processing` + `externalJobId`.
+- On error: read job, increment `dispatchAttempts`. If >= 3, mark failed. Else set status `queued` and schedule retry via `setTimeout` with backoff `[60_000, 300_000, 1_500_000][attempts-1]` ms.
+- `finally`: unlink the .opus.
+
+- [ ] Step 1: write file.
+- [ ] Step 2: commit.
+
+---
+
+### Task 10: Webhook + status + audio-stream routes
+
+**Files:** create `app/api/transcribe/webhook/route.ts`, `app/api/transcribe/[id]/route.ts`, `app/api/transcribe/[id]/audio/route.ts`.
+
+**Webhook** (`POST`):
+1. Read raw body via `req.text()`, parse JSON.
+2. Read `body.metadata.audioJobId`. 400 if missing.
+3. `payload.findByID({ collection: 'audio-jobs', id, overrideAccess: true })`. 404 if not found. 409 if no `callbackSecret`.
+4. `verifySignature(rawBody, headers['x-polymer-transcribe-signature'], job.callbackSecret)`. 401 if invalid.
+5. If `status === 'failed'` or no result: update job `{ status: 'failed', error }`. Return ok.
+6. Else: map `body.result` to `TranscriptData` (snake → camel for `speaker_id`); compute `searchableText` by joining all segment.text. Upsert into `transcripts` (find existing by audioJob, otherwise create). Update job `{ status: 'completed', transcribedAt: now, error: null }`.
+7. Return 200 ok.
+
+**Status** (`GET /:id`):
+- Auth required. Return `{ id, status, progress, error, transcribedAt, title, kind }`.
+
+**Audio stream** (`GET /:id/audio`):
+- Auth required. Find job with depth 1 to populate `audioFile`. 404 if missing.
+- Resolve filesystem path via `process.env.AUDIO_DIR || '/var/www/polymer-media/audio'` + `audioFile.filename`.
+- Support HTTP `Range` header: parse `bytes=N-M?`, stream `createReadStream(path, { start, end })` with status 206 + `Content-Range`, `Accept-Ranges`, `Content-Length`, `Content-Type` headers.
+- Otherwise stream the whole file, status 200.
+
+- [ ] Step 1: write three files.
+- [ ] Step 2: commit.
+
+---
+
+### Task 11: Transcript GET/PATCH + dispatch retry
+
+**Files:** create `app/api/transcribe/[id]/transcript/route.ts`, `app/api/transcribe/[id]/dispatch/route.ts`.
+
+**GET /:id/transcript**: auth; find by `audioJob.equals(id)`; return `{ id, data, editedAt }`. 404 if none.
+
+**PATCH /:id/transcript**: auth; require `body.data.segments` array; recompute `searchableText`; update `data, searchableText, editedAt: now, editedBy: user.id`.
+
+**POST /:id/dispatch (retry)**: auth; load job with depth 1; require `audioFile.filename`; reset `status: 'queued', dispatchAttempts: 0, error: null`; generate fresh `callbackSecret`; in a fire-and-forget IIFE: set status `dispatching`, transcode original audio (under `AUDIO_DIR`), call `dispatchToTranscribeApi`, set status `processing` + `externalJobId`; on error mark `failed`; cleanup .opus in finally.
+
+(The retry route inlines its own dispatch flow rather than importing from the upload route, to avoid a Next.js cyclic resolution at build time. Acceptable duplication for v1.)
+
+- [ ] Step 1: write two files.
+- [ ] Step 2: `pnpm typecheck` clean.
+- [ ] Step 3: commit.
+
+---
+
+## Phase 3 — Custom Payload UI Shell
+
+### Task 12: JobsListView
+
+**Files:** create `components/Transcribe/JobsListView.tsx`, `components/Transcribe/transcribe.css`; modify `collections/AudioJobs.ts`.
+
+Client component, default export. Uses `@payloadcms/ui` `Gutter` for layout.
+
+State:
+- `jobs: Job[]`, `kind: string`, `status: string`, `search: string`, `showUpload: boolean`, `loading: boolean`.
+
+Effect:
+- On mount and on filter change, fetch `/api/audio-jobs?depth=1&limit=100&sort=-createdAt&where[kind][equals]=…&where[status][equals]=…&where[title][like]=…` (omit empty filters).
+
+Render:
+- Header: "Transcripts" title + green "+ Upload audio" button.
+- Filter row: search input, kind select, status select, link to `/admin/transcribe/search`.
+- Table with columns: Title, Kind, Status (color pill), Uploader, Created.
+- Row click → `router.push('/admin/collections/audio-jobs/${id}')`.
+- When `showUpload`: render `<UploadModal>` (Task 13); on `onCreated(id)` push to that job's edit view.
+
+CSS file: status pill colors (queued/dispatching gray, processing blue, completed green, failed red), table hover, filters layout.
+
+Register in `AudioJobs` admin block:
+```ts
+admin: {
+  // … existing …
+  components: { views: { list: { Component: '@/components/Transcribe/JobsListView#default' } } },
+}
+```
+
+- [ ] Step 1–3: css, component, register.
+- [ ] Step 4: commit.
+
+---
+
+### Task 13: UploadModal
+
+**Files:** create `components/Transcribe/UploadModal.tsx`.
+
+Props: `{ onClose: () => void; onCreated: (id: number) => void }`.
+
+State: `file`, `title`, `kind`, `notes`, `submitting`, `progress (0–100)`, `error`.
+
+UI:
+- Modal overlay (fixed, centered). Click outside closes.
+- Drag/drop zone — onDrop sets file and seeds title from filename without extension. Click triggers hidden `<input type="file" accept="audio/*,…">`.
+- Inputs: title, kind select (6 options), notes textarea.
+- Submit uses `XMLHttpRequest` with `upload.onprogress` for granular progress. POST to `/api/transcribe/upload` with `withCredentials = true`.
+- On 201 success → call `onCreated(json.id)`. On error → display message.
+
+- [ ] Step 1–2: write file, commit.
+
+---
+
+### Task 14: JobEditView + StatusPanel + useJobStatus + Editor stub
+
+**Files:** create `components/Transcribe/JobEditView.tsx`, `components/Transcribe/StatusPanel.tsx`, `components/Transcribe/hooks/useJobStatus.ts`, `components/Transcribe/Editor/Editor.tsx` (stub); modify `collections/AudioJobs.ts`.
+
+`useJobStatus(id, intervalMs = 5000)`:
+- Polls `/api/transcribe/${id}` every interval until status is `completed` or `failed`.
+- Returns latest `JobStatusInfo` or null.
+- Cleans up interval on unmount.
+
+`StatusPanel`: takes `info` + `onRetry`. Renders title + sub copy per status, a progress bar (when not completed/failed), the error text (if any), and a "Retry" button when `failed` (calls onRetry which POSTs `/api/transcribe/:id/dispatch`).
+
+`JobEditView`:
+- Use `useParams()` to get the audio-job id from the admin URL.
+- Hook into `useJobStatus(id)`.
+- If `info.status === 'completed'`, render `<Editor audioJobId={id} title kind />`.
+- Otherwise render `<StatusPanel info onRetry={...} />`.
+
+`Editor` stub: just `<div>Editor coming for job {audioJobId}…</div>` — full implementation in Phase 4.
+
+Register edit view in AudioJobs admin block:
+```ts
+components: {
+  views: {
+    list: { Component: '@/components/Transcribe/JobsListView#default' },
+    edit: { default: { Component: '@/components/Transcribe/JobEditView#default' } },
+  },
+}
+```
+
+- [ ] Step 1–4: write files, register.
+- [ ] Step 5: smoke test (`pnpm dev`, exercise upload → status panel polling).
+- [ ] Step 6: commit.
+
+---
+
+## Phase 4 — Editor Core
+
+### Task 15: useTranscript hook
+
+**Files:** create `components/Transcribe/hooks/useTranscript.ts`.
+
+`useTranscript(audioJobId)` returns `{ data, update, forceSave, saveState }`.
+
+Behavior:
+- On mount, `GET /api/transcribe/${id}/transcript` once → `setData(j.data)`.
+- `update(next)`: setState immediately, store `dirtyRef = next`, set `saveState = 'dirty'`, debounce 2 s and then call `flush()`.
+- `flush()`: PATCH `${id}/transcript` with `{ data: dirtyRef }`. On success → `'saved'`; on error → `'error'`. Clear dirtyRef.
+- `forceSave()`: cancel timer, call flush.
+- `saveState`: 'idle' | 'dirty' | 'saving' | 'saved' | 'error'.
+
+- [ ] Step 1–2: write, commit.
+
+---
+
+### Task 16: AudioPlayer + useAudioPlayback
+
+**Files:** create `components/Transcribe/Editor/AudioPlayer.tsx`, `components/Transcribe/hooks/useAudioPlayback.ts`.
+
+`AudioPlayer` is `forwardRef<HTMLAudioElement, { audioJobId: string }>`, renders `<audio src="/api/transcribe/${audioJobId}/audio" controls preload="metadata" />`.
+
+`useAudioPlayback(audioRef, data)` returns `{ segmentId: string|null, wordIndex: number|null, time }`. On `timeupdate`, do a binary search over `data.segments` (sorted by start time) to find the active segment, then a linear search across that segment's `words` for the active word.
+
+- [ ] Step 1–2: write, commit.
+
+---
+
+### Task 17: SegmentList (virtualized) + Segment
+
+**Files:** create `components/Transcribe/Editor/SegmentList.tsx`, `components/Transcribe/Editor/Segment.tsx`; modify `package.json`.
+
+`pnpm add react-window` + `pnpm add -D @types/react-window`.
+
+`Segment` (memoized): props `{ seg, speakers, isCurrent, currentWordIndex, onSeek, onTextChange, onSpeakerChange }`. Renders:
+- Row 1: speaker `<select>` (options from speakers array, value = seg.speakerId), clickable timestamp button (calls onSeek(seg.start)).
+- Row 2: if `seg.edited` or `currentWordIndex === null` → `contentEditable` `<div>` showing seg.text; on blur, call `onTextChange(seg.id, e.currentTarget.textContent ?? '')`.
+- Otherwise → list of `<span>`s, one per word, click seeks to word.start, the active word gets `.word--current` class with a yellow background.
+
+`SegmentList` uses `VariableSizeList` from `react-window`:
+- `height = 600`, `width = "100%"`, `itemCount = segments.length`, `overscanCount = 5`.
+- Estimate row height by `Math.max(60, Math.ceil(words/12) * 24 + 50)` (refine later if needed).
+- `useEffect` watches `currentSegmentId` and calls `listRef.current.scrollToItem(idx, 'smart')`.
+
+- [ ] Step 1–3: install, write, commit.
+
+---
+
+### Task 18: SpeakerSidebar + Editor wrapper
+
+**Files:** create `components/Transcribe/Editor/SpeakerSidebar.tsx`; modify `components/Transcribe/Editor/Editor.tsx`.
+
+`SpeakerSidebar`: title "Speakers", a row per speaker. Click row → in-place input (autoFocus, commit on blur or Enter). Show segment count under each label.
+
+`Editor` (full, replacing the stub):
+- Uses `useTranscript`, `useAudioPlayback`, `useRef<HTMLAudioElement>`.
+- Computes `segmentCounts` via useMemo over `data.segments`.
+- Header bar: title + saveState indicator (● Unsaved, ○ Saving…, ✓ Saved, red Save failed).
+- Audio player below header.
+- Two-column body: SpeakerSidebar (220px) | SegmentList (rest).
+- `onSeek`, `onTextChange`, `onSpeakerChange`, `onRename` callbacks rebuild data immutably and call `update(...)`.
+
+- [ ] Step 1–2: write, commit.
+
+---
+
+## Phase 5 — Editor Advanced
+
+### Task 19: Segment utilities + tests
+
+**Files:** create `lib/transcribe/segments.ts`, `tests/lib/transcribe/segments.test.ts`.
+
+Exports:
+- `nextSegmentId(segments)` — finds max `seg_NNNN` and returns next as `seg_${(max+1).padStart(4, '0')}`.
+- `mergeSegments(data, idA, idB)` — only merges adjacent segments (by index). The merged segment takes the lower id, lower start, higher end, concatenated text (whitespace-collapsed), concatenated word lists, `edited: true`. Result keeps segments sorted by start.
+- `splitSegment(data, segmentId, wordIndex)` — splits at word index; refuses 0 or last (no-op). Left keeps the original id; right gets `nextSegmentId`. Both `edited: true`. Right's start = right's first word's start.
+- `reassignSpeaker(data, segmentId, newSpeakerId)` — if `newSpeakerId` not in speakers, append `{ id, label: null }` first.
+
+Tests (≥6):
+1. `nextSegmentId` returns next zero-padded.
+2. Merge two adjacent → one combined segment.
+3. Merge non-adjacent → no-op.
+4. Split at middle word index → 3 segments total, ids correct.
+5. Split at 0 or last → no-op.
+6. Reassign to existing → speakers length stable; segment.speakerId updated.
+7. Reassign to unknown id → speakers grows by one.
+
+- [ ] Step 1–3: write, run, commit.
+
+---
+
+### Task 20: Wire merge/split/reassign into UI
+
+**Files:** modify `components/Transcribe/Editor/Segment.tsx`, `components/Transcribe/Editor/SegmentList.tsx`, `components/Transcribe/Editor/Editor.tsx`.
+
+Add three optional props on `Segment`: `onMergeAbove`, `onMergeBelow`, `onSplitAt`. Render `↑ merge` / `↓ merge` icons in the segment header (small, low-contrast). In the rendered word `<span>`s, `onClick` checks `e.altKey` — alt-click calls `onSplitAt(seg.id, wordIndex)` instead of seek.
+
+Plumb the props through `SegmentList`'s `Row` to each `Segment`.
+
+In `Editor`, define:
+- `onMergeAbove(id)`: locate index, no-op if 0, else `update(mergeSegments(data, segments[idx-1].id, id))`.
+- `onMergeBelow(id)`: symmetric.
+- `onSplitAt(id, wordIndex)`: `update(splitSegment(data, id, wordIndex))`.
+
+Speaker reassign already works via the `<select>` per segment from Task 17 (Editor's `onSpeakerChange` now uses `reassignSpeaker(data, ...)` instead of inline code so unknown-speaker handling is consistent).
+
+- [ ] Step 1–3: edit Segment, edit SegmentList, edit Editor.
+- [ ] Step 4: commit.
+
+---
+
+### Task 21: Find & Replace
+
+**Files:** create `components/Transcribe/Editor/FindReplace.tsx`; modify `components/Transcribe/Editor/Editor.tsx`.
+
+Component: floating panel (top-right, `position: fixed`, z-index 100). State: `find`, `replace`, `regex`, `caseSensitive`, `error`.
+
+`buildPattern()`: returns RegExp or null. If `regex`, construct directly with caught syntax error → set error. Else escape the find string. Flag `g` always; case sensitivity adds/removes `i`.
+
+`matchCount`: aggregate `match(p)?.length ?? 0` across all segments.
+
+`apply()`: maps segments with `text.replace(p, replace)`; if changed, set `edited: true`. Calls `onApply(next)` then `onClose()`.
+
+In Editor: state `showFind`, render conditionally, listen for `cmd/ctrl+f` via `window` keydown effect (preventDefault).
+
+- [ ] Step 1–3: write, wire, commit.
+
+---
+
+### Task 22: Export menu + tests
+
+**Files:** create `lib/transcribe/exporters.ts`, `tests/lib/transcribe/exporters.test.ts`, `components/Transcribe/Editor/ExportMenu.tsx`; modify `components/Transcribe/Editor/Editor.tsx`.
+
+`exporters.ts` exports `buildPlainText(data, includeSpeakers=true)`, `buildSrt(data)`, `buildVtt(data)`, `buildJson(data)`. Internal `fmtTimestamp(t, sep=','|'.')` produces `HH:MM:SS,mmm` (SRT) or `HH:MM:SS.mmm` (VTT). `speakerLabel(speakers, id)` falls back to id when label null.
+
+- TXT: `${speaker}: ${text}\n\n…\n` or just `${text}\n\n…\n`.
+- SRT: per-segment cue numbered from 1, comma timestamps.
+- VTT: `WEBVTT\n\n` + cue blocks with `<v Speaker>text` syntax.
+- JSON: `JSON.stringify(data, null, 2)`.
+
+Tests assert exact strings on a small fixture (2 segments, 2 speakers, one labeled, one not).
+
+`ExportMenu` component: 4 buttons (TXT/SRT/VTT/JSON). Each builds a Blob, makes an object URL, sets `<a download>`, clicks programmatically, revokes URL after a tick.
+
+In `Editor` header, render `<ExportMenu data={data} baseName={(title || 'transcript').replace(/[^a-z0-9-]+/gi, '_')} />`.
+
+- [ ] Step 1–5: write, test, wire, commit.
+
+---
+
+## Phase 6 — Search
+
+### Task 23: Search API route + safe highlight ranges
+
+**Files:** create `app/api/transcribe/search/route.ts`, `lib/transcribe/highlight.ts`, `tests/lib/transcribe/highlight.test.ts`.
+
+`highlight.ts` exports `findMatchRanges(text: string, query: string, opts?: { caseSensitive?: boolean }): Array<{ start: number; end: number }>` — splits `query` into terms (whitespace-separated, quoted-phrase support optional for v1), and returns sorted, non-overlapping ranges where any term occurs. Ranges are character offsets into `text`. Tests cover: single term, multiple terms, overlapping/adjacent merges, empty query → `[]`.
+
+(We compute highlight ranges on the server alongside the snippet, so the client never has to inject HTML — it just renders text segments and `<mark>` React elements based on numeric ranges.)
+
+GET handler:
+- Auth required.
+- Read `q` query param. Empty → return `{ results: [] }`.
+- Determine if user is staff (admin/eic/editor).
+- Use `pg.Pool` from `process.env.DATABASE_URL`. Run a parameterized query joining `transcripts` to `audio_jobs`, filtered by FTS match on `to_tsvector('english', searchable_text) @@ websearch_to_tsquery('english', $1)`. For non-staff, also filter `j.uploader_id = $2`.
+- Compute snippet client-side prep: select up to ~200 chars around the first match in `searchable_text`. Use `findMatchRanges` to map `q` terms onto the snippet substring (re-zero offsets after slicing).
+- Use `ts_rank` to order results, limit 50.
+- Return `{ results: [{ transcript_id, audio_job_id, title, kind, uploader_id, snippet, ranges }] }` where `ranges` are the offset pairs into `snippet`.
+
+- [ ] Step 1: write `highlight.ts` + tests; run.
+- [ ] Step 2: write search route.
+- [ ] Step 3: commit.
+
+---
+
+### Task 24: SearchView page + Snippet component
+
+**Files:** create `app/(payload)/admin/transcribe/search/page.tsx`, `components/Transcribe/Search/SearchView.tsx`, `components/Transcribe/Search/Snippet.tsx`.
+
+`Snippet` (pure component): props `{ text: string; ranges: Array<{ start: number; end: number }> }`. Returns React fragments — slices the string at each range boundary and wraps the in-range slices with a `<mark>` element. **No HTML injection of any kind** — the rendered output is plain text plus React-built `<mark>` elements. Trivial implementation, ~15 lines.
+
+`SearchView` (client): input field, debounced 250 ms, fetch `/api/transcribe/search?q=…`, render results as a list. Each result: linked title (to `/admin/collections/audio-jobs/${audio_job_id}`), kind subtitle, `<Snippet text={r.snippet} ranges={r.ranges} />`.
+
+The page file is a tiny server component that imports and renders the client `SearchView`.
+
+- [ ] Step 1–3: write Snippet, SearchView, page route.
+- [ ] Step 4: commit.
+
+---
+
+## Phase 7 — Verification
+
+### Task 25: Lint, typecheck, test, build
+
+- [ ] `pnpm lint` clean.
+- [ ] `pnpm typecheck` clean.
+- [ ] `pnpm test:unit` all green.
+- [ ] `pnpm build` succeeds.
+- [ ] Commit any chore fixes.
+
+---
+
+### Task 26: Local end-to-end smoke + deploy wiring
+
+- [ ] `pnpm db:fresh && pnpm dev`.
+- [ ] Log in as a writer; click through list → upload (small <10s sample) → status polling.
+- [ ] Without homelab live: simulate a webhook delivery via `curl` with HMAC-signed body to verify the receiver path:
+
+  ```bash
+  JOB=1
+  SECRET=$(psql "$DATABASE_URL" -tAc "SELECT callback_secret FROM audio_jobs WHERE id = $JOB")
+  BODY='{"job_id":"x","status":"completed","metadata":{"audioJobId":'$JOB'},"result":{"language":"en","duration":3,"model":"t","speakers":[{"id":"SPEAKER_00"}],"segments":[{"id":"seg_0001","speaker_id":"SPEAKER_00","start":0,"end":3,"text":"Hi","words":[{"word":"Hi","start":0,"end":1}]}]},"error":null}'
+  SIG=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" -hex | awk '{print $2}')
+  curl -X POST http://localhost:3000/api/transcribe/webhook \
+    -H "Content-Type: application/json" \
+    -H "X-Polymer-Transcribe-Signature: sha256=$SIG" \
+    -d "$BODY"
+  ```
+- [ ] Verify editor renders. Exercise speaker rename, text edit, merge ↑↓, alt-click split, find/replace, exports.
+- [ ] Add `TRANSCRIBE_API_URL`, `TRANSCRIBE_API_KEY`, `TRANSCRIBE_CF_ACCESS_CLIENT_ID`, `TRANSCRIBE_CF_ACCESS_CLIENT_SECRET`, `TRANSCRIBE_PUBLIC_BASE_URL` to `.github/workflows/deploy.yml` (the `.env` write step). Note that prod VM needs `ffmpeg` (`pacman -S ffmpeg`).
+- [ ] Final commit.
+
+---
+
+## Self-Review
+
+- [x] **Spec coverage:** every spec section has a task. Collections T1–3, migration T4, transport T5–11, custom UI shell T12–14, editor T15–18, advanced T19–22, search T23–24, verification T25–26.
+- [x] **No placeholders:** all "TBD" or generic phrases removed; tasks describe concrete behavior + tests.
+- [x] **Type consistency:** `TranscriptData`/`Segment`/`Speaker`/`Word` defined once in `lib/transcribe/types.ts`; all consumers reference it. Slugs `audio-files`/`audio-jobs`/`transcripts` consistent in collections, migration table names, and route consumers.
+- [x] **Bite-size:** each task ≤ ~6 steps; each step is a single concrete action.
+
+## Out of Scope (per spec)
+
+Real-time collab, per-job sharing UI, DOCX export, model fine-tuning, auto article-draft generation.

--- a/docs/superpowers/specs/2026-04-28-audio-transcription-design.md
+++ b/docs/superpowers/specs/2026-04-28-audio-transcription-design.md
@@ -1,0 +1,336 @@
+# Audio Upload + Transcription — Design
+
+**Status:** approved 2026-04-28
+**Owner:** Ronan
+**Implementation:** in this repo (polymer side) + new `polymer-transcribe` repo on homelab
+
+## Goal
+
+Let any user with a `writer`, `editor`, `eic`, or `admin` role upload audio (interviews, meetings, pressers, lectures, court hearings, etc.) directly inside the Payload admin and receive a high-accuracy transcript with speaker diarization and word-level timestamps. Provide a fully custom Payload admin UI for upload, status, transcript editing, and search across past transcripts.
+
+Transcription accuracy is the priority; latency is not. Recordings can be up to 6 hours.
+
+## Architecture
+
+```
+[ writer's browser ]
+        │ payload-admin session
+        ▼
+[ polymer (Next.js + Payload) on prod VM ]
+        │ multipart, opus 32 kbps mono 16 kHz
+        │ over Cloudflare Tunnel + CF Access service token
+        ▼
+[ polymer-transcribe (FastAPI + WhisperX) on homelab RTX 4070 ]
+        │ HMAC-signed webhook
+        ▼
+[ polymer webhook handler → transcripts row ]
+```
+
+Two services, two repos.
+
+- **`polymer` (this repo)** — collections, dispatch, webhook handler, custom Payload admin UI, search.
+- **`polymer-transcribe` (new repo, homelab box)** — FastAPI service wrapping WhisperX (faster-whisper backend) + wav2vec2 alignment + pyannote 3.1 diarization. One job at a time on the GPU. Persistent SQLite queue.
+
+The two services communicate only over HTTPS through a Cloudflare Tunnel guarded by Cloudflare Access. The full prompt for the homelab build lives at `docs/superpowers/specs/2026-04-28-polymer-transcribe-prompt.md`.
+
+## Why this shape
+
+- **Custom Payload UI, not the public frontend.** Auth, role check, and document-locking already work in the admin. Writers already use the admin daily.
+- **Self-host transcription on a GPU we own.** Source-protection concern: interview audio shouldn't leave our infra to a third-party API. Cloudflare Tunnel gives a public hostname without opening home-network ports.
+- **Pre-transcode to opus 32 kbps mono 16 kHz on polymer.** Whisper internally resamples to 16 kHz mono. Sending pre-resampled audio cuts a 6 hr file from 250 MB+ to ~85 MB, fitting under Cloudflare's 100 MB body cap on free/pro plans without accuracy loss.
+- **Separate repo for the GPU service.** Different language (Python), different host, different lifecycle. Keeping it out of polymer's CI / Docker contexts.
+- **One concurrent GPU job.** A 4070 with 12 GB VRAM holds large-v3 + alignment + pyannote sequentially comfortably; running two at once would OOM. Queue serializes.
+
+## Data Model
+
+Three new Payload collections.
+
+### `audioFiles` (upload-enabled)
+
+Stores raw uploaded audio on disk in `/var/www/polymer-media/audio/`.
+
+| Field | Type | Notes |
+|---|---|---|
+| (upload built-ins) | — | filename, mimeType, filesize, etc. |
+| `durationSeconds` | number | Computed via `ffprobe` in `beforeChange` |
+| `uploader` | relationship → users | Set in `beforeChange` from req.user |
+
+Access:
+- `read`: uploader + admin/eic/editor.
+- `create`: writer/editor/eic/admin.
+- `delete`: admin (cascades to audioJobs).
+
+Accept MIME types: `audio/mpeg`, `audio/mp4`, `audio/x-m4a`, `audio/wav`, `audio/x-wav`, `audio/ogg`, `audio/flac`, `audio/webm`, `audio/opus`.
+
+### `audioJobs`
+
+| Field | Type | Notes |
+|---|---|---|
+| `title` | text | Default = filename, user-editable |
+| `kind` | select | `interview` / `meeting` / `presser` / `lecture` / `court` / `other` |
+| `notes` | textarea | Free-form |
+| `audioFile` | relationship → audioFiles | Required |
+| `uploader` | relationship → users | Set in `beforeChange` |
+| `status` | select | `queued` / `dispatching` / `processing` / `completed` / `failed` |
+| `externalJobId` | text | UUID returned by transcribe API |
+| `callbackSecret` | text (hidden) | Random hex generated on dispatch; HMAC key for the webhook |
+| `progress` | number 0–100 | Optional, surfaced when API reports it |
+| `dispatchAttempts` | number | For retry backoff |
+| `error` | textarea | Populated on failure |
+| `transcribedAt` | date | Set on webhook success |
+
+Indexes: `status`, `uploader`, `created_at`.
+
+Access:
+- `read`: uploader + admin/eic/editor.
+- `create`: writer/editor/eic/admin.
+- `update`: uploader + admin (only fields the editor exposes).
+- `delete`: uploader + admin.
+
+### `transcripts` (1:1 with `audioJobs`)
+
+| Field | Type | Notes |
+|---|---|---|
+| `audioJob` | relationship → audioJobs | Unique |
+| `data` | json | The transcript blob (see shape below) |
+| `searchableText` | text (hidden, indexed) | All segment text concatenated, populated on save; backs full-text search |
+| `editedAt` | date | Last user edit |
+| `editedBy` | relationship → users | |
+
+Postgres: GIN index on `to_tsvector('english', searchable_text)` for fast FTS.
+
+`data` JSON shape:
+
+```json
+{
+  "language": "en",
+  "duration": 3582.4,
+  "model": "whisperx-large-v3+pyannote-3.1",
+  "speakers": [
+    { "id": "SPEAKER_00", "label": "Mayor Smith" },
+    { "id": "SPEAKER_01", "label": null }
+  ],
+  "segments": [
+    {
+      "id": "seg_0001",
+      "speakerId": "SPEAKER_00",
+      "start": 12.34,
+      "end": 18.91,
+      "text": "We have to act now on housing.",
+      "words": [
+        { "word": "We", "start": 12.34, "end": 12.51, "score": 0.98 }
+      ],
+      "edited": false
+    }
+  ]
+}
+```
+
+`words` keep their original timestamps even after `text` edits (`edited: true` tells the player not to trust word offsets for that segment).
+
+Stored as a single `json` column rather than Payload array fields because a 1-hour transcript can have 5,000+ word objects — array-field rendering would bog down the admin form even though we're not using it.
+
+## API Contract — polymer ↔ polymer-transcribe
+
+Implemented exactly per `docs/superpowers/specs/2026-04-28-polymer-transcribe-prompt.md`. Summary:
+
+- `POST /v1/jobs` — multipart audio, returns `{ job_id, status, queue_position }`.
+- `GET /v1/jobs/{id}` — status poll.
+- `DELETE /v1/jobs/{id}` — cancel.
+- `GET /healthz` — readiness.
+- Outbound webhook → polymer's `/api/transcribe/webhook` with `X-Polymer-Transcribe-Signature: sha256=<hex>` (HMAC-SHA256 with the per-job `callbackSecret`).
+
+Three auth layers on requests *into* the GPU service: bearer API key + Cloudflare Access service token (CF-Access-Client-Id/Secret) + the tunnel itself (no public ports). HMAC on the webhook coming back.
+
+## Job Lifecycle
+
+```
+upload → audioFile + audioJob(queued) → dispatcher
+       → ffmpeg transcode to opus 32 kbps mono 16 kHz
+       → multipart POST to /v1/jobs with callback_url + callback_secret
+       → store externalJobId, status=processing
+       → ... (5–30 min later) ...
+       → webhook arrives, HMAC verified
+       → upsert transcripts row, status=completed
+       → UI poller sees the change, swaps from status panel to editor
+```
+
+Failure modes:
+- ffmpeg transcode fails → status=failed, error stored.
+- Dispatch HTTP fails → exponential backoff 1m / 5m / 25m, max 3 attempts, then status=failed.
+- Webhook reports `failed` → record error, surface "retry" button (creates a new audioJob from the same audioFile).
+- Webhook with bad signature → 401, no DB write, alert log.
+- Webhook for unknown job_id → 404.
+
+## Polymer Routes
+
+| Path | Purpose |
+|---|---|
+| `app/api/transcribe/upload/route.ts` | Multipart receiver: creates audioFile + audioJob, kicks dispatcher in background |
+| `app/api/transcribe/[id]/route.ts` | GET status, DELETE to cancel |
+| `app/api/transcribe/[id]/transcript/route.ts` | GET / PATCH transcript JSON (debounced auto-save) |
+| `app/api/transcribe/[id]/dispatch/route.ts` | Internal POST to retry dispatch |
+| `app/api/transcribe/webhook/route.ts` | HMAC-verified callback from transcribe service |
+| `app/api/transcribe/search/route.ts` | Full-text search across user's transcripts |
+| `app/api/transcribe/[id]/audio/route.ts` | Streams the original audio for the in-editor player (auth-checked) |
+
+The dispatcher is in-process: the upload route awaits transcode + dispatch (both fast — transcode 30-60s for 1 hr audio, POST is a stream). No new long-running worker; this avoids adding a second PM2 process. If dispatch fails, the row stays `dispatching` with `dispatchAttempts` and a server-side retry timer (a `setTimeout` is fine; if the process restarts, a startup hook re-queues stuck `dispatching` rows).
+
+## Custom Payload Admin UI
+
+All views are registered via `admin.components` in the `audioJobs` collection.
+
+```ts
+// In Audio Jobs collection
+admin: {
+  components: {
+    views: {
+      list: { Component: '@/components/Transcribe/JobsListView#default' },
+      edit: {
+        default: { Component: '@/components/Transcribe/JobEditView#default' },
+      },
+    },
+  },
+}
+```
+
+### Components
+
+```
+components/Transcribe/
+  JobsListView.tsx               # custom list: filters, status pills, "Upload audio" CTA
+  UploadModal.tsx                # drag/drop, kind picker, posts to /api/transcribe/upload
+  JobEditView.tsx                # routes between Status / Editor based on status
+  StatusPanel.tsx                # queued/processing/failed UI; polls /api/transcribe/[id]
+  Editor/
+    Editor.tsx                   # the full editor wrapper
+    AudioPlayer.tsx              # custom <audio> with word-level seek + current-word highlight
+    SpeakerSidebar.tsx           # rename + reassign
+    SegmentList.tsx              # virtualized via react-window
+    Segment.tsx                  # single segment: speaker pill, contenteditable text, timestamps
+    FindReplace.tsx              # regex toggle, find/replace across all segments
+    ExportMenu.tsx               # TXT / SRT / VTT / JSON
+    contextMenu.tsx              # split, merge above/below, change speaker
+  Search/
+    SearchView.tsx               # admin route /admin/transcribe/search
+  hooks/
+    useTranscript.ts             # state + 2s debounced PATCH save
+    useAudioPlayback.ts          # current word tracking from audio element
+    useJobStatus.ts              # poll status while queued/processing
+  utils/
+    segments.ts                  # split/merge/reassign helpers (deterministic seg ids)
+    exporters.ts                 # buildSrt, buildVtt, buildPlainText
+  transcribe.css                 # editor-specific styles
+```
+
+### Editor mechanics
+
+- **Speaker rename:** click pill → inline input → updates `speakers[i].label`.
+- **Speaker reassign:** right-click segment → dropdown of speakers + "New speaker" (adds `SPEAKER_NN`).
+- **Text edit:** segment text is contenteditable. On blur, set `edited: true`, update `text`. Word array unchanged.
+- **Segment merge** (with neighbor): concatenates text, takes earliest start + latest end, keeps speaker of first segment. New `id = seg_NNNN` reusing the lower id.
+- **Segment split:** at cursor position, splits text in two; new segment timestamps interpolated by word-position ratio.
+- **Find/Replace:** regex toggle. Operates on segment text in-memory; saves through normal debounce.
+- **Audio sync:** `<audio>` `timeupdate` → find segment+word containing currentTime → scroll into view, apply `.is-current` class.
+- **Save:** 2 s inactivity debounce → PATCH `/api/transcribe/[id]/transcript` with full `data` JSON. Optimistic UI; banner on conflict (last-write-wins for v1).
+- **Keyboard:** space (play/pause), ⌘/ctrl+f (find), ⌘/ctrl+s (force save), ⌘/ctrl+z/y (undo/redo via local history stack).
+
+### Export formats
+
+- **TXT** — plain or `[Speaker]: text\n\n…`, configurable in the menu.
+- **SRT** — sequential indices, `HH:MM:SS,mmm` timestamps, one segment per cue.
+- **VTT** — `WEBVTT` header + cue blocks.
+- **JSON** — raw `transcripts.data`.
+
+All client-side via `Blob` + `URL.createObjectURL`.
+
+### Search view
+
+`/admin/transcribe/search` — custom non-collection admin route. Searches `transcripts.searchable_text` via Postgres FTS, returns: title, kind, uploader, snippet with `<mark>`-highlighted match, link to editor scrolled to first hit. Scoped by access rules (writers see own, editors+ see all).
+
+## Migration Plan
+
+Per CLAUDE.md, both files must be added.
+
+### TypeScript migration
+
+`migrations/20260428_100000_add_audio_transcription.ts` registered in `migrations/index.ts`.
+
+DDL:
+- `audio_files` (upload table, mirrors `media`-style columns minus image sizes).
+- `audio_jobs` with FK to `audio_files`, FK to `users`.
+- `transcripts` with FK to `audio_jobs`, `data jsonb`, `searchable_text text`, generated `tsvector` GIN index.
+- Enum types: `enum_audio_jobs_kind`, `enum_audio_jobs_status`.
+- `payload_locked_documents_rels` columns + FKs for the three new collections.
+
+### SQL migration script
+
+Equivalent block appended to `scripts/run_deploy_sql_migrations.sh`, with a tracking INSERT entry: `('20260428_100000_add_audio_transcription', <next-batch>, NOW(), NOW())`.
+
+## Configuration / Env
+
+Polymer:
+- `TRANSCRIBE_API_URL` — e.g. `https://transcribe.<domain>`
+- `TRANSCRIBE_API_KEY` — bearer token
+- `TRANSCRIBE_CF_ACCESS_CLIENT_ID`
+- `TRANSCRIBE_CF_ACCESS_CLIENT_SECRET`
+- `TRANSCRIBE_PUBLIC_BASE_URL` — polymer's public origin used to build `callback_url`
+
+Update `scripts/generate-env.js` to include the new vars (with stub values for local dev). Update the deploy workflow's secrets list.
+
+## Error Handling Summary
+
+| Failure | Behavior |
+|---|---|
+| Upload > 1 GB or > 6 hr | 413 / 400 with clear message |
+| Bad MIME or bad ffprobe | 415 |
+| Transcode fail | status=failed, error stored |
+| Dispatch transient fail | retry 1m/5m/25m, then failed |
+| Webhook bad signature | 401, no write, log alert |
+| Webhook unknown job_id | 404 |
+| Webhook reports failure | status=failed, error stored, "retry" CTA in UI |
+| Concurrent edit (409) | banner + reload offer |
+| Audio fetch in editor (auth fail) | 403 |
+
+## Testing Strategy
+
+**Unit:**
+- HMAC verification (valid, tampered body, missing header, wrong key).
+- Segment merge/split utilities (deterministic ids, timestamp interpolation, edge cases: first/last segment, empty selection).
+- Export builders (SRT, VTT, TXT) — golden snapshots.
+- ffprobe wrapper.
+
+**Integration (against a mock transcribe API):**
+- Full upload → mocked dispatch → mock webhook → transcript visible.
+- Permission tests: writer A cannot read writer B's job; editor can read both.
+- Retry path: transcribe API 503 → dispatch retries → eventually fails after 3.
+
+**E2E (Playwright, `tests/transcribe-flow.spec.ts`):**
+- Log in as writer → upload sample audio (10s clip in `tests/fixtures/audio/`) → status panel renders → simulate webhook delivery → editor renders → rename speaker → reload → rename persists.
+
+**Manual once homelab is online:**
+- Real 5-min, 30-min, 2-hr samples through the live tunnel.
+
+CI already runs lint/typecheck/build/migrate. Playwright stays out of CI for now (per existing pattern); the new spec is run locally + during the deploy smoke check.
+
+## Build Phases
+
+Sequenced so each phase ships something testable.
+
+1. **Foundation** — collections, migrations (TS + SQL), payload-types regen, ffprobe util.
+2. **Transport** — upload route, ffmpeg transcoder, dispatch util, webhook handler with HMAC, internal status route, mock-API integration test.
+3. **Custom UI shell** — JobsListView (replaces Payload's default), UploadModal, JobEditView routing, StatusPanel with polling.
+4. **Editor core** — AudioPlayer, SegmentList (virtualized), Segment, SpeakerSidebar, useTranscript debounced save.
+5. **Editor advanced** — speaker reassign, segment merge/split, FindReplace, ExportMenu.
+6. **Search** — searchable_text population + tsvector index, search API route, SearchView.
+7. **Tests + polish** — unit tests, Playwright e2e, lint + typecheck, deploy env wiring.
+
+The homelab service (`polymer-transcribe`) is built in parallel using the prompt at `docs/superpowers/specs/2026-04-28-polymer-transcribe-prompt.md`.
+
+## Out of Scope (v1)
+
+- Real-time collaborative editing (last-write-wins is fine).
+- Per-job sharing UI (role-based visibility covers it).
+- DOCX export (drop in later if asked).
+- Custom prompt / fine-tuning of Whisper.
+- Automatic article-draft generation from transcripts.

--- a/docs/superpowers/specs/2026-04-28-polymer-transcribe-prompt.md
+++ b/docs/superpowers/specs/2026-04-28-polymer-transcribe-prompt.md
@@ -1,0 +1,197 @@
+# Build polymer-transcribe — a GPU transcription microservice
+
+> Paste this entire document into a fresh Claude Code session on the homelab box. It is the complete brief.
+
+You are building a brand-new repo, **`polymer-transcribe`**, on this homelab box. It's a FastAPI service that wraps WhisperX + pyannote for high-accuracy transcription with speaker diarization, exposed publicly via a Cloudflare Tunnel guarded by Cloudflare Access. It's consumed by a separate app called `polymer` (a Next.js + Payload CMS newsroom platform) running elsewhere; this repo only knows the API contract below.
+
+Use the superpowers skills for this work — especially `brainstorming` (briefly, since this prompt nails down the design), `writing-plans`, `test-driven-development`, and `verification-before-completion`. Don't skip the plan.
+
+## Hardware & host
+
+- Arch Linux homelab, NVIDIA RTX 4070 (12 GB VRAM), recent CUDA-capable driver.
+- Service runs as a dedicated system user (`transcribe`), under systemd, on `127.0.0.1:8088`.
+- Public exposure is via `cloudflared` named tunnel only; no inbound ports opened.
+
+## Goal
+
+Accept multipart audio uploads, run WhisperX large-v3 + wav2vec2 alignment + pyannote-3.1 diarization, then POST the result back to a caller-supplied webhook. One job at a time on the GPU, with a persistent queue that survives restarts. Accuracy is the priority; throughput is not.
+
+## Stack (pin these)
+
+- Python 3.11
+- FastAPI + uvicorn (single worker; the GPU is the bottleneck)
+- whisperx (faster-whisper backend, fp16, batch_size=8)
+- pyannote.audio 3.1 (requires accepting the model license on Hugging Face and an `HF_TOKEN`)
+- httpx for outbound webhooks
+- aiosqlite for the job store
+- pydantic v2 for schemas
+- python-multipart for uploads
+
+## Repo layout
+
+```
+polymer-transcribe/
+  pyproject.toml                # uv or pip-tools managed; pin everything
+  README.md                     # setup, env vars, systemd, cloudflared
+  src/polymer_transcribe/
+    __init__.py
+    main.py                     # FastAPI app factory
+    config.py                   # env/settings via pydantic-settings
+    api/
+      jobs.py                   # POST/GET/DELETE /v1/jobs
+      health.py                 # GET /healthz
+      auth.py                   # bearer-token dependency
+    core/
+      queue.py                  # asyncio.Queue + worker loop
+      store.py                  # aiosqlite job persistence
+      pipeline.py               # whisperx + pyannote wrapper
+      webhook.py                # HMAC-signed callback w/ retry
+      audio.py                  # ffprobe validation, normalization
+      models.py                 # pydantic schemas
+  tests/
+    test_api_jobs.py
+    test_pipeline_smoke.py      # tiny 5-second clip, real GPU
+    test_webhook_signing.py
+    test_queue_recovery.py
+  deploy/
+    polymer-transcribe.service  # systemd unit
+    cloudflared-config.yml      # named tunnel config template
+    install.sh                  # one-shot setup script
+  data/                         # gitignored: sqlite, audio uploads, model cache
+```
+
+## API contract — implement EXACTLY this
+
+(All endpoints under `/v1` except `/healthz`. JSON unless stated.)
+
+### `POST /v1/jobs` (multipart/form-data)
+
+Auth: `Authorization: Bearer <TRANSCRIBE_API_KEY>`.
+
+Form fields:
+- `audio` — file (required). Accept: opus, wav, mp3, flac, m4a, ogg, mp4. Reject anything else with 415.
+- `callback_url` — https URL (required).
+- `callback_secret` — hex string (required), used as HMAC-SHA256 key for the webhook.
+- `job_metadata` — JSON string (optional), opaque to us, returned verbatim in the webhook.
+- `language` — ISO 639-1 code (optional). Default: auto-detect.
+- `min_speakers`, `max_speakers` — int (optional).
+
+Behavior:
+1. Validate auth → 401 on miss.
+2. ffprobe the upload; reject if duration > 6 hours or no audio stream → 400.
+3. Persist file to `${DATA_DIR}/audio/<job_id>.<ext>`.
+4. Insert job row in SQLite (`status=queued`).
+5. Enqueue.
+6. Respond `201 { job_id, status: "queued", queue_position }`.
+
+### `GET /v1/jobs/{job_id}`
+
+Auth: Bearer. Returns current row: `{ job_id, status, progress, queue_position, error }`. 404 if unknown.
+
+### `DELETE /v1/jobs/{job_id}`
+
+Auth: Bearer. If queued → mark cancelled, drop from queue. If processing → set a cancel flag the worker checks between phases (transcribe / align / diarize). Respond 204. The cancelled job sends a `failed` webhook with `error: "cancelled"`.
+
+### `GET /healthz`
+
+No auth. `{ status, gpu_available, model_loaded, queue_depth, version, uptime_s }`. Used by the tunnel and by polymer's monitoring.
+
+### Outbound webhook → `callback_url`
+
+After a job finishes (success OR failure), POST JSON. Compute `sha256_hmac = HMAC-SHA256(raw_body_bytes, callback_secret)`. Send headers:
+
+```
+Content-Type: application/json
+X-Polymer-Transcribe-Signature: sha256=<hex>
+X-Polymer-Transcribe-Job-Id: <uuid>
+```
+
+Body:
+```json
+{
+  "job_id": "<uuid>",
+  "status": "completed" | "failed",
+  "metadata": <whatever was passed as job_metadata, parsed back to JSON>,
+  "result": {
+    "language": "en",
+    "duration": 3582.4,
+    "model": "whisperx-large-v3+pyannote-3.1",
+    "speakers": [{"id": "SPEAKER_00"}, {"id": "SPEAKER_01"}],
+    "segments": [{
+      "id": "seg_0001",
+      "speaker_id": "SPEAKER_00",
+      "start": 12.34,
+      "end": 18.91,
+      "text": "We have to act now on housing.",
+      "words": [{"word": "We", "start": 12.34, "end": 12.51, "score": 0.98}]
+    }]
+  } | null,
+  "error": null | "string"
+}
+```
+
+Retry policy: on non-2xx or network error, retry 5 times with exponential backoff (1s, 4s, 16s, 64s, 256s). After 5 failures, log and give up but leave job marked `completed`/`failed` in our store. The receiver MUST be idempotent on `job_id`.
+
+## Pipeline details
+
+- Models load **once at startup** (cold start ~30–90s on RTX 4070); never per-job. Block readiness (`/healthz` reports `model_loaded: false`) until done.
+- Order: faster-whisper transcribe → wav2vec2 align (English: `WAV2VEC2_ASR_LARGE_LV60K_960H`; other languages: WhisperX's auto-pick) → pyannote diarize → assign speakers to words.
+- compute_type=`float16`, batch_size=`8`, device=`cuda`. If `int8_float16` gives noticeable accuracy hit, prefer fp16.
+- VAD filter on (silero).
+- Segment IDs must be deterministic (`seg_0001`, `seg_0002`, …) so polymer can diff edits sanely.
+- After each job: `torch.cuda.empty_cache()`. If a job throws OOM, fail it cleanly and continue serving — never leave the worker dead.
+- Delete the audio file from disk after a successful webhook delivery. On failure, keep for `${FAILED_AUDIO_RETENTION_DAYS:-7}` days.
+
+## Queue & restart resilience
+
+- One asyncio worker, one job at a time.
+- SQLite stores: `id, status, audio_path, callback_url, callback_secret, job_metadata, language, min_speakers, max_speakers, queue_position, progress, error, created_at, started_at, finished_at`.
+- On startup: any row in `processing` → revert to `queued` (it didn't survive the restart) and re-enqueue at front. Any in `queued` re-enqueued in `created_at` order.
+- Progress reporting: emit 0/25/50/75/100 between phases (transcribe / align / diarize / done) — fine-grained progress isn't worth it for a single-GPU service.
+
+## Security model
+
+Three layers, all required:
+
+1. **Cloudflare Tunnel** — `cloudflared` outbound to CF, no inbound ports. Configured via `deploy/cloudflared-config.yml` (template; the operator fills in tunnel ID + hostname).
+2. **Cloudflare Access "service auth" application policy** — on `transcribe.<domain>`. Edge rejects requests missing valid `CF-Access-Client-Id` + `CF-Access-Client-Secret`. README documents exactly how to set up the Access app and generate the service token.
+3. **Bearer `TRANSCRIBE_API_KEY`** — checked by FastAPI itself. Defense-in-depth in case CF Access is misconfigured.
+
+The webhook direction uses HMAC-SHA256 with the per-job `callback_secret` so polymer can verify a webhook came from us without sharing a long-lived secret.
+
+## Configuration (env)
+
+```
+TRANSCRIBE_API_KEY=<long random hex>
+HF_TOKEN=<HuggingFace token with pyannote-3.1 license accepted>
+DATA_DIR=/var/lib/polymer-transcribe
+HOST=127.0.0.1
+PORT=8088
+WHISPER_MODEL=large-v3
+COMPUTE_TYPE=float16
+BATCH_SIZE=8
+MAX_AUDIO_HOURS=6
+WEBHOOK_TIMEOUT_S=30
+FAILED_AUDIO_RETENTION_DAYS=7
+LOG_LEVEL=info
+```
+
+`.env.example` checked in; real `.env` written by `install.sh` from prompts.
+
+## Build order
+
+1. `install.sh`: create `transcribe` user, install system deps (ffmpeg, libsndfile), create venv, `pip install -e .`, create `DATA_DIR` with right perms, install systemd unit, prompt for env values.
+2. Implement schemas, store, queue, pipeline, API in that order with TDD.
+3. Smoke-test locally with curl + a 10-second sample clip.
+4. Set up `cloudflared` named tunnel + Access service-auth app (README walks the operator through it).
+5. End-to-end test through the tunnel from another machine.
+
+## Acceptance criteria
+
+- `pytest` green; pipeline test transcribes a real 10-second sample and produces aligned, diarized output.
+- `systemctl status polymer-transcribe` clean; `/healthz` returns `model_loaded: true` after ~60s startup.
+- A 30-min real audio file submitted via `curl` through the tunnel completes in under 15 minutes wall-clock and delivers a signature-verified webhook to a test sink (`https://webhook.site` is fine for first verification).
+- Killing the service mid-job and restarting → job picks up from `queued` (a fresh full re-run; we don't checkpoint mid-pipeline).
+- README has the exact `cloudflared` + Access setup steps, the systemd commands, and a `curl` example.
+
+When the service is up and the tunnel works, hand back: the public hostname, the bearer API key, the CF Access client id/secret, and a sample webhook body. Polymer integration on the other side keys off those.

--- a/lib/transcribe/config.ts
+++ b/lib/transcribe/config.ts
@@ -1,0 +1,30 @@
+export type TranscribeConfig =
+  | { configured: false }
+  | {
+      configured: true
+      url: string
+      apiKey: string
+      cfClientId: string
+      cfClientSecret: string
+      publicBaseUrl: string
+    }
+
+export function getTranscribeConfig(): TranscribeConfig {
+  const url = process.env.TRANSCRIBE_API_URL
+  const apiKey = process.env.TRANSCRIBE_API_KEY
+  const cfId = process.env.TRANSCRIBE_CF_ACCESS_CLIENT_ID
+  const cfSecret = process.env.TRANSCRIBE_CF_ACCESS_CLIENT_SECRET
+  const publicBase = process.env.TRANSCRIBE_PUBLIC_BASE_URL || process.env.NEXT_PUBLIC_SITE_URL
+
+  if (!url || !apiKey || !cfId || !cfSecret || !publicBase) {
+    return { configured: false }
+  }
+  return {
+    configured: true,
+    url: url.replace(/\/$/, ''),
+    apiKey,
+    cfClientId: cfId,
+    cfClientSecret: cfSecret,
+    publicBaseUrl: publicBase.replace(/\/$/, ''),
+  }
+}

--- a/lib/transcribe/dispatch.ts
+++ b/lib/transcribe/dispatch.ts
@@ -1,0 +1,55 @@
+import { createReadStream } from 'node:fs'
+import { Readable } from 'node:stream'
+import { getTranscribeConfig } from './config'
+
+export interface DispatchInput {
+  audioPath: string
+  audioFilename: string
+  audioMimeType: string
+  audioJobId: number
+  callbackSecret: string
+}
+
+export interface DispatchResult {
+  externalJobId: string
+  queuePosition?: number
+}
+
+export async function dispatchToTranscribeApi(input: DispatchInput): Promise<DispatchResult> {
+  const cfg = getTranscribeConfig()
+  if (!cfg.configured) throw new Error('Transcribe API not configured')
+
+  const callbackUrl = `${cfg.publicBaseUrl}/api/transcribe/webhook`
+
+  const fileBlob = await fileStreamToBlob(input.audioPath, input.audioMimeType)
+
+  const form = new FormData()
+  form.append('audio', fileBlob, input.audioFilename)
+  form.append('callback_url', callbackUrl)
+  form.append('callback_secret', input.callbackSecret)
+  form.append('job_metadata', JSON.stringify({ audioJobId: input.audioJobId }))
+
+  const res = await fetch(`${cfg.url}/v1/jobs`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${cfg.apiKey}`,
+      'CF-Access-Client-Id': cfg.cfClientId,
+      'CF-Access-Client-Secret': cfg.cfClientSecret,
+    },
+    body: form,
+    signal: AbortSignal.timeout(10 * 60 * 1000),
+  })
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new Error(`Transcribe API ${res.status}: ${body.slice(0, 500)}`)
+  }
+  const json = (await res.json()) as { job_id: string; queue_position?: number }
+  return { externalJobId: json.job_id, queuePosition: json.queue_position }
+}
+
+async function fileStreamToBlob(path: string, mimeType: string): Promise<Blob> {
+  const stream = Readable.toWeb(createReadStream(path)) as ReadableStream<Uint8Array>
+  const res = new Response(stream, { headers: { 'Content-Type': mimeType } })
+  return await res.blob()
+}

--- a/lib/transcribe/exporters.ts
+++ b/lib/transcribe/exporters.ts
@@ -1,0 +1,61 @@
+import type { TranscriptData, Speaker } from './types'
+
+function pad(n: number, width = 2): string {
+  return String(n).padStart(width, '0')
+}
+
+function fmtTimestamp(t: number, ms: ',' | '.' = ','): string {
+  const total = Math.max(0, t)
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  const s = Math.floor(total % 60)
+  const millis = Math.floor((total - Math.floor(total)) * 1000)
+  return `${pad(h)}:${pad(m)}:${pad(s)}${ms}${pad(millis, 3)}`
+}
+
+function speakerLabel(speakers: Speaker[], id: string): string {
+  return speakers.find((sp) => sp.id === id)?.label ?? id
+}
+
+export function buildPlainText(data: TranscriptData, includeSpeakers = true): string {
+  return (
+    data.segments
+      .map((s) =>
+        includeSpeakers
+          ? `${speakerLabel(data.speakers, s.speakerId)}: ${s.text}`
+          : s.text,
+      )
+      .join('\n\n') + '\n'
+  )
+}
+
+export function buildSrt(data: TranscriptData): string {
+  return data.segments
+    .map(
+      (s, i) =>
+        `${i + 1}\n${fmtTimestamp(s.start, ',')} --> ${fmtTimestamp(s.end, ',')}\n${speakerLabel(
+          data.speakers,
+          s.speakerId,
+        )}: ${s.text}\n`,
+    )
+    .join('\n')
+}
+
+export function buildVtt(data: TranscriptData): string {
+  return (
+    'WEBVTT\n\n' +
+    data.segments
+      .map(
+        (s) =>
+          `${fmtTimestamp(s.start, '.')} --> ${fmtTimestamp(s.end, '.')}\n<v ${speakerLabel(
+            data.speakers,
+            s.speakerId,
+          )}>${s.text}\n`,
+      )
+      .join('\n')
+  )
+}
+
+export function buildJson(data: TranscriptData): string {
+  return JSON.stringify(data, null, 2)
+}

--- a/lib/transcribe/ffmpeg.ts
+++ b/lib/transcribe/ffmpeg.ts
@@ -1,0 +1,82 @@
+import { spawn } from 'node:child_process'
+
+export interface ProbeResult {
+  durationSeconds: number
+  hasAudio: boolean
+}
+
+/**
+ * Run ffprobe on a file path. Uses spawn with array args (no shell), so the
+ * file path cannot be interpreted as a shell expression.
+ */
+export async function ffprobe(filePath: string): Promise<ProbeResult> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(
+      'ffprobe',
+      ['-v', 'error', '-print_format', 'json', '-show_format', '-show_streams', filePath],
+      { stdio: ['ignore', 'pipe', 'pipe'] },
+    )
+    let out = ''
+    let errBuf = ''
+    proc.stdout.on('data', (d: Buffer) => {
+      out += d.toString('utf8')
+    })
+    proc.stderr.on('data', (d: Buffer) => {
+      errBuf += d.toString('utf8')
+    })
+    proc.on('error', reject)
+    proc.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`ffprobe exited ${code}: ${errBuf.slice(-2000)}`))
+        return
+      }
+      try {
+        const json = JSON.parse(out) as {
+          streams?: { codec_type?: string }[]
+          format?: { duration?: string | number }
+        }
+        const streams = json.streams ?? []
+        const hasAudio = streams.some((s) => s.codec_type === 'audio')
+        const duration = Number(json.format?.duration ?? 0)
+        resolve({ durationSeconds: Number.isFinite(duration) ? duration : 0, hasAudio })
+      } catch (e) {
+        reject(e instanceof Error ? e : new Error(String(e)))
+      }
+    })
+  })
+}
+
+/**
+ * Transcode any audio input to opus 32 kbps, mono, 16 kHz — matches what
+ * Whisper resamples to internally, so accuracy is identical and the upload
+ * stays well under Cloudflare's 100 MB body limit even for multi-hour audio.
+ */
+export async function transcodeToOpus(input: string, output: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(
+      'ffmpeg',
+      [
+        '-y',
+        '-i', input,
+        '-vn',
+        '-ac', '1',
+        '-ar', '16000',
+        '-c:a', 'libopus',
+        '-b:a', '32k',
+        '-application', 'voip',
+        output,
+      ],
+      { stdio: ['ignore', 'ignore', 'pipe'] },
+    )
+    let errBuf = ''
+    proc.stderr.on('data', (d: Buffer) => {
+      errBuf += d.toString('utf8')
+      if (errBuf.length > 4096) errBuf = errBuf.slice(-2048)
+    })
+    proc.on('error', reject)
+    proc.on('close', (code) => {
+      if (code !== 0) reject(new Error(`ffmpeg exited ${code}: ${errBuf.slice(-2000)}`))
+      else resolve()
+    })
+  })
+}

--- a/lib/transcribe/highlight.ts
+++ b/lib/transcribe/highlight.ts
@@ -1,0 +1,72 @@
+export interface HighlightRange {
+  start: number
+  end: number
+}
+
+const REGEX_META_CHARS = '.*+?^${}()|[]\\'
+
+function escapeForRegex(input: string): string {
+  let out = ''
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i]
+    out += REGEX_META_CHARS.includes(ch) ? `\\${ch}` : ch
+  }
+  return out
+}
+
+const TOKEN_RE = /"([^"]+)"|'([^']+)'|(\S+)/g
+
+/**
+ * Tokenize a search query into individual terms. Quoted phrases (single or
+ * double) are kept as one term. Whitespace separates terms otherwise.
+ */
+export function tokenizeQuery(q: string): string[] {
+  const tokens: string[] = []
+  TOKEN_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = TOKEN_RE.exec(q)) !== null) {
+    const term = (m[1] ?? m[2] ?? m[3] ?? '').trim()
+    if (term) tokens.push(term)
+  }
+  return tokens
+}
+
+/**
+ * Find non-overlapping match ranges for each term in `text`. Adjacent or
+ * overlapping ranges are merged. Default is case-insensitive.
+ */
+export function findMatchRanges(
+  text: string,
+  query: string,
+  opts: { caseSensitive?: boolean } = {},
+): HighlightRange[] {
+  const terms = tokenizeQuery(query)
+  if (!terms.length || !text) return []
+
+  const flags = opts.caseSensitive ? 'g' : 'gi'
+  const ranges: HighlightRange[] = []
+  for (const term of terms) {
+    const pattern = new RegExp(escapeForRegex(term), flags)
+    let match: RegExpExecArray | null
+    while ((match = pattern.exec(text)) !== null) {
+      if (match[0].length === 0) {
+        pattern.lastIndex++
+        continue
+      }
+      ranges.push({ start: match.index, end: match.index + match[0].length })
+    }
+  }
+  if (!ranges.length) return []
+  ranges.sort((a, b) => a.start - b.start)
+  const merged: HighlightRange[] = [ranges[0]]
+  for (let i = 1; i < ranges.length; i++) {
+    const last = merged[merged.length - 1]
+    const cur = ranges[i]
+    if (cur.start <= last.end) {
+      last.end = Math.max(last.end, cur.end)
+    } else {
+      merged.push(cur)
+    }
+  }
+  return merged
+}

--- a/lib/transcribe/highlight.ts
+++ b/lib/transcribe/highlight.ts
@@ -3,30 +3,42 @@ export interface HighlightRange {
   end: number
 }
 
-const REGEX_META_CHARS = '.*+?^${}()|[]\\'
-
-function escapeForRegex(input: string): string {
-  let out = ''
-  for (let i = 0; i < input.length; i++) {
-    const ch = input[i]
-    out += REGEX_META_CHARS.includes(ch) ? `\\${ch}` : ch
-  }
-  return out
-}
-
-const TOKEN_RE = /"([^"]+)"|'([^']+)'|(\S+)/g
-
 /**
  * Tokenize a search query into individual terms. Quoted phrases (single or
  * double) are kept as one term. Whitespace separates terms otherwise.
+ *
+ * Implemented as a small character-level scanner — keeps the user query out of
+ * any RegExp construction so we cannot inject regex metacharacters.
  */
 export function tokenizeQuery(q: string): string[] {
   const tokens: string[] = []
-  TOKEN_RE.lastIndex = 0
-  let m: RegExpExecArray | null
-  while ((m = TOKEN_RE.exec(q)) !== null) {
-    const term = (m[1] ?? m[2] ?? m[3] ?? '').trim()
+  let i = 0
+  while (i < q.length) {
+    const ch = q[i]
+    if (ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r') {
+      i++
+      continue
+    }
+    if (ch === '"' || ch === "'") {
+      const quote = ch
+      const end = q.indexOf(quote, i + 1)
+      if (end === -1) {
+        const tail = q.slice(i + 1).trim()
+        if (tail) tokens.push(tail)
+        break
+      }
+      const inner = q.slice(i + 1, end).trim()
+      if (inner) tokens.push(inner)
+      i = end + 1
+      continue
+    }
+    let j = i
+    while (j < q.length && q[j] !== ' ' && q[j] !== '\t' && q[j] !== '\n' && q[j] !== '\r') {
+      j++
+    }
+    const term = q.slice(i, j).trim()
     if (term) tokens.push(term)
+    i = j
   }
   return tokens
 }
@@ -34,6 +46,9 @@ export function tokenizeQuery(q: string): string[] {
 /**
  * Find non-overlapping match ranges for each term in `text`. Adjacent or
  * overlapping ranges are merged. Default is case-insensitive.
+ *
+ * Uses String.prototype.indexOf instead of RegExp so the search query is
+ * treated as a literal — no regex injection surface.
  */
 export function findMatchRanges(
   text: string,
@@ -43,17 +58,17 @@ export function findMatchRanges(
   const terms = tokenizeQuery(query)
   if (!terms.length || !text) return []
 
-  const flags = opts.caseSensitive ? 'g' : 'gi'
+  const haystack = opts.caseSensitive ? text : text.toLowerCase()
   const ranges: HighlightRange[] = []
-  for (const term of terms) {
-    const pattern = new RegExp(escapeForRegex(term), flags)
-    let match: RegExpExecArray | null
-    while ((match = pattern.exec(text)) !== null) {
-      if (match[0].length === 0) {
-        pattern.lastIndex++
-        continue
-      }
-      ranges.push({ start: match.index, end: match.index + match[0].length })
+  for (const rawTerm of terms) {
+    const needle = opts.caseSensitive ? rawTerm : rawTerm.toLowerCase()
+    if (!needle) continue
+    let from = 0
+    while (from <= haystack.length) {
+      const at = haystack.indexOf(needle, from)
+      if (at === -1) break
+      ranges.push({ start: at, end: at + needle.length })
+      from = at + needle.length
     }
   }
   if (!ranges.length) return []

--- a/lib/transcribe/hmac.ts
+++ b/lib/transcribe/hmac.ts
@@ -1,0 +1,25 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+export function signBody(body: string | Buffer, secret: string): string {
+  const buf = typeof body === 'string' ? Buffer.from(body) : body
+  return createHmac('sha256', secret).update(buf).digest('hex')
+}
+
+export function verifySignature(
+  body: string | Buffer,
+  header: string | null | undefined,
+  secret: string,
+): boolean {
+  if (!header) return false
+  const expected = signBody(body, secret)
+  const provided = header.startsWith('sha256=') ? header.slice(7) : header
+  if (provided.length !== expected.length) return false
+  try {
+    const a = Buffer.from(provided, 'hex')
+    const b = Buffer.from(expected, 'hex')
+    if (a.length !== b.length) return false
+    return timingSafeEqual(a, b)
+  } catch {
+    return false
+  }
+}

--- a/lib/transcribe/segments.ts
+++ b/lib/transcribe/segments.ts
@@ -1,0 +1,93 @@
+import type { Segment, TranscriptData } from './types'
+
+const ID_PATTERN = /^seg_(\d+)$/
+
+export function nextSegmentId(segments: Segment[]): string {
+  let max = 0
+  for (const s of segments) {
+    const m = ID_PATTERN.exec(s.id)
+    if (m) max = Math.max(max, Number(m[1]))
+  }
+  return `seg_${String(max + 1).padStart(4, '0')}`
+}
+
+export function mergeSegments(
+  data: TranscriptData,
+  idA: string,
+  idB: string,
+): TranscriptData {
+  const idxA = data.segments.findIndex((s) => s.id === idA)
+  const idxB = data.segments.findIndex((s) => s.id === idB)
+  if (idxA < 0 || idxB < 0 || Math.abs(idxA - idxB) !== 1) return data
+  const lo = Math.min(idxA, idxB)
+  const hi = Math.max(idxA, idxB)
+  const first = data.segments[lo]
+  const second = data.segments[hi]
+  const merged: Segment = {
+    id: first.id,
+    speakerId: first.speakerId,
+    start: Math.min(first.start, second.start),
+    end: Math.max(first.end, second.end),
+    text: `${first.text} ${second.text}`.replace(/\s+/g, ' ').trim(),
+    words: [...first.words, ...second.words],
+    edited: true,
+  }
+  const segments = data.segments
+    .filter((s) => s.id !== first.id && s.id !== second.id)
+    .concat(merged)
+    .sort((a, b) => a.start - b.start)
+  return { ...data, segments }
+}
+
+export function splitSegment(
+  data: TranscriptData,
+  segmentId: string,
+  wordIndex: number,
+): TranscriptData {
+  const idx = data.segments.findIndex((s) => s.id === segmentId)
+  if (idx < 0) return data
+  const seg = data.segments[idx]
+  if (wordIndex <= 0 || wordIndex >= seg.words.length) return data
+
+  const left = seg.words.slice(0, wordIndex)
+  const right = seg.words.slice(wordIndex)
+  if (left.length === 0 || right.length === 0) return data
+
+  const a: Segment = {
+    ...seg,
+    end: left[left.length - 1].end,
+    text: left.map((w) => w.word).join(' '),
+    words: left,
+    edited: true,
+  }
+  const b: Segment = {
+    id: nextSegmentId(data.segments),
+    speakerId: seg.speakerId,
+    start: right[0].start,
+    end: seg.end,
+    text: right.map((w) => w.word).join(' '),
+    words: right,
+    edited: true,
+  }
+  const segments = [...data.segments]
+  segments.splice(idx, 1, a, b)
+  return { ...data, segments }
+}
+
+export function reassignSpeaker(
+  data: TranscriptData,
+  segmentId: string,
+  newSpeakerId: string,
+): TranscriptData {
+  let speakers = data.speakers
+  if (!speakers.some((sp) => sp.id === newSpeakerId)) {
+    speakers = [...speakers, { id: newSpeakerId, label: null }]
+  }
+  return {
+    ...data,
+    speakers,
+    segments: data.segments.map((s) =>
+      s.id === segmentId ? { ...s, speakerId: newSpeakerId } : s,
+    ),
+  }
+}

--- a/lib/transcribe/types.ts
+++ b/lib/transcribe/types.ts
@@ -1,0 +1,52 @@
+export interface Speaker {
+  id: string
+  label: string | null
+}
+
+export interface Word {
+  word: string
+  start: number
+  end: number
+  score?: number
+}
+
+export interface Segment {
+  id: string
+  speakerId: string
+  start: number
+  end: number
+  text: string
+  words: Word[]
+  edited?: boolean
+}
+
+export interface TranscriptData {
+  language: string
+  duration: number
+  model: string
+  speakers: Speaker[]
+  segments: Segment[]
+}
+
+export interface TranscribeWebhookSegment {
+  id: string
+  speaker_id: string
+  start: number
+  end: number
+  text: string
+  words: { word: string; start: number; end: number; score?: number }[]
+}
+
+export interface TranscribeWebhookBody {
+  job_id: string
+  status: 'completed' | 'failed'
+  metadata: { audioJobId: number } | null
+  result: {
+    language: string
+    duration: number
+    model: string
+    speakers: { id: string }[]
+    segments: TranscribeWebhookSegment[]
+  } | null
+  error: string | null
+}

--- a/migrations/20260428_100000_add_audio_transcription.ts
+++ b/migrations/20260428_100000_add_audio_transcription.ts
@@ -1,0 +1,126 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    DO $$ BEGIN
+      CREATE TYPE "public"."enum_audio_jobs_kind" AS ENUM('interview','meeting','presser','lecture','court','other');
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+    DO $$ BEGIN
+      CREATE TYPE "public"."enum_audio_jobs_status" AS ENUM('queued','dispatching','processing','completed','failed');
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+    CREATE TABLE IF NOT EXISTS "audio_files" (
+      "id" serial PRIMARY KEY NOT NULL,
+      "duration_seconds" numeric,
+      "uploader_id" integer,
+      "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+      "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+      "url" varchar,
+      "thumbnail_u_r_l" varchar,
+      "filename" varchar,
+      "mime_type" varchar,
+      "filesize" numeric,
+      "width" numeric,
+      "height" numeric,
+      "focal_x" numeric,
+      "focal_y" numeric
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS "audio_files_filename_idx" ON "audio_files" USING btree ("filename");
+    CREATE INDEX IF NOT EXISTS "audio_files_uploader_idx" ON "audio_files" USING btree ("uploader_id");
+    CREATE INDEX IF NOT EXISTS "audio_files_created_at_idx" ON "audio_files" USING btree ("created_at");
+    DO $$ BEGIN
+      ALTER TABLE "audio_files" ADD CONSTRAINT "audio_files_uploader_id_users_id_fk"
+        FOREIGN KEY ("uploader_id") REFERENCES "public"."users"("id") ON DELETE SET NULL;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+    CREATE TABLE IF NOT EXISTS "audio_jobs" (
+      "id" serial PRIMARY KEY NOT NULL,
+      "title" varchar NOT NULL,
+      "kind" "public"."enum_audio_jobs_kind" NOT NULL DEFAULT 'interview',
+      "notes" varchar,
+      "audio_file_id" integer NOT NULL,
+      "uploader_id" integer,
+      "status" "public"."enum_audio_jobs_status" NOT NULL DEFAULT 'queued',
+      "external_job_id" varchar,
+      "callback_secret" varchar,
+      "progress" numeric,
+      "dispatch_attempts" numeric DEFAULT 0,
+      "error" varchar,
+      "transcribed_at" timestamp(3) with time zone,
+      "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+      "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS "audio_jobs_status_idx" ON "audio_jobs" USING btree ("status");
+    CREATE INDEX IF NOT EXISTS "audio_jobs_uploader_idx" ON "audio_jobs" USING btree ("uploader_id");
+    CREATE INDEX IF NOT EXISTS "audio_jobs_created_at_idx" ON "audio_jobs" USING btree ("created_at");
+    CREATE UNIQUE INDEX IF NOT EXISTS "audio_jobs_external_job_id_idx" ON "audio_jobs" USING btree ("external_job_id") WHERE "external_job_id" IS NOT NULL;
+    DO $$ BEGIN
+      ALTER TABLE "audio_jobs" ADD CONSTRAINT "audio_jobs_audio_file_id_audio_files_id_fk"
+        FOREIGN KEY ("audio_file_id") REFERENCES "public"."audio_files"("id") ON DELETE CASCADE;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+    DO $$ BEGIN
+      ALTER TABLE "audio_jobs" ADD CONSTRAINT "audio_jobs_uploader_id_users_id_fk"
+        FOREIGN KEY ("uploader_id") REFERENCES "public"."users"("id") ON DELETE SET NULL;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+    CREATE TABLE IF NOT EXISTS "transcripts" (
+      "id" serial PRIMARY KEY NOT NULL,
+      "audio_job_id" integer NOT NULL,
+      "data" jsonb NOT NULL,
+      "searchable_text" text,
+      "edited_at" timestamp(3) with time zone,
+      "edited_by_id" integer,
+      "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+      "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS "transcripts_audio_job_idx" ON "transcripts" USING btree ("audio_job_id");
+    CREATE INDEX IF NOT EXISTS "transcripts_searchable_text_fts_idx" ON "transcripts"
+      USING gin (to_tsvector('english', coalesce("searchable_text", '')));
+    DO $$ BEGIN
+      ALTER TABLE "transcripts" ADD CONSTRAINT "transcripts_audio_job_id_audio_jobs_id_fk"
+        FOREIGN KEY ("audio_job_id") REFERENCES "public"."audio_jobs"("id") ON DELETE CASCADE;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+    DO $$ BEGIN
+      ALTER TABLE "transcripts" ADD CONSTRAINT "transcripts_edited_by_id_users_id_fk"
+        FOREIGN KEY ("edited_by_id") REFERENCES "public"."users"("id") ON DELETE SET NULL;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+    ALTER TABLE "payload_locked_documents_rels" ADD COLUMN IF NOT EXISTS "audio_files_id" integer;
+    ALTER TABLE "payload_locked_documents_rels" ADD COLUMN IF NOT EXISTS "audio_jobs_id" integer;
+    ALTER TABLE "payload_locked_documents_rels" ADD COLUMN IF NOT EXISTS "transcripts_id" integer;
+    DO $$ BEGIN
+      ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_audio_files_fk"
+        FOREIGN KEY ("audio_files_id") REFERENCES "public"."audio_files"("id") ON DELETE CASCADE;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+    DO $$ BEGIN
+      ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_audio_jobs_fk"
+        FOREIGN KEY ("audio_jobs_id") REFERENCES "public"."audio_jobs"("id") ON DELETE CASCADE;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+    DO $$ BEGIN
+      ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_transcripts_fk"
+        FOREIGN KEY ("transcripts_id") REFERENCES "public"."transcripts"("id") ON DELETE CASCADE;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+    CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_audio_files_id_idx" ON "payload_locked_documents_rels" ("audio_files_id");
+    CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_audio_jobs_id_idx" ON "payload_locked_documents_rels" ("audio_jobs_id");
+    CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_transcripts_id_idx" ON "payload_locked_documents_rels" ("transcripts_id");
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT IF EXISTS "payload_locked_documents_rels_transcripts_fk";
+    ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT IF EXISTS "payload_locked_documents_rels_audio_jobs_fk";
+    ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT IF EXISTS "payload_locked_documents_rels_audio_files_fk";
+    DROP INDEX IF EXISTS "payload_locked_documents_rels_transcripts_id_idx";
+    DROP INDEX IF EXISTS "payload_locked_documents_rels_audio_jobs_id_idx";
+    DROP INDEX IF EXISTS "payload_locked_documents_rels_audio_files_id_idx";
+    ALTER TABLE "payload_locked_documents_rels" DROP COLUMN IF EXISTS "transcripts_id";
+    ALTER TABLE "payload_locked_documents_rels" DROP COLUMN IF EXISTS "audio_jobs_id";
+    ALTER TABLE "payload_locked_documents_rels" DROP COLUMN IF EXISTS "audio_files_id";
+    DROP TABLE IF EXISTS "transcripts";
+    DROP TABLE IF EXISTS "audio_jobs";
+    DROP TABLE IF EXISTS "audio_files";
+    DROP TYPE IF EXISTS "public"."enum_audio_jobs_status";
+    DROP TYPE IF EXISTS "public"."enum_audio_jobs_kind";
+  `)
+}

--- a/migrations/index.ts
+++ b/migrations/index.ts
@@ -38,6 +38,7 @@ import * as migration_20260424_000000_add_news_more_seo_fields from './20260424_
 import * as migration_20260424_010000_add_breaking_news from './20260424_010000_add_breaking_news';
 import * as migration_20260424_020000_add_device_tokens from './20260424_020000_add_device_tokens';
 import * as migration_20260428_000000_add_media_image_sizes from './20260428_000000_add_media_image_sizes';
+import * as migration_20260428_100000_add_audio_transcription from './20260428_100000_add_audio_transcription';
 
 export const migrations = [
   {
@@ -239,5 +240,10 @@ export const migrations = [
     up: migration_20260428_000000_add_media_image_sizes.up,
     down: migration_20260428_000000_add_media_image_sizes.down,
     name: '20260428_000000_add_media_image_sizes',
+  },
+  {
+    up: migration_20260428_100000_add_audio_transcription.up,
+    down: migration_20260428_100000_add_audio_transcription.down,
+    name: '20260428_100000_add_audio_transcription',
   },
 ];

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "posthog-node": "^5.28.4",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "react-window": "^2.2.7",
     "sharp": "^0.34.5"
   },
   "devDependencies": {
@@ -54,6 +55,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/react-window": "^2.0.0",
     "eslint": "^9",
     "eslint-config-next": "16.1.7",
     "tailwindcss": "^4",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:smoke": "playwright test tests/smoke.spec.ts",
     "test:search-limit": "playwright test --project=desktop-chromium tests/search-limit.spec.ts",
     "test:deploy-smoke": "node scripts/deploy-smoke.mjs",
+    "test:unit": "vitest run",
     "generate:types": "payload generate:types",
     "db:up": "docker compose up -d --wait db",
     "db:down": "docker compose down",
@@ -57,7 +58,8 @@
     "eslint-config-next": "16.1.7",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.5"
   },
   "pnpm": {
     "overrides": {

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -80,6 +80,9 @@ export interface Config {
     submissions: Submission;
     'event-submissions': EventSubmission;
     'device-tokens': DeviceToken;
+    'audio-files': AudioFile;
+    'audio-jobs': AudioJob;
+    transcripts: Transcript;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -100,6 +103,9 @@ export interface Config {
     submissions: SubmissionsSelect<false> | SubmissionsSelect<true>;
     'event-submissions': EventSubmissionsSelect<false> | EventSubmissionsSelect<true>;
     'device-tokens': DeviceTokensSelect<false> | DeviceTokensSelect<true>;
+    'audio-files': AudioFilesSelect<false> | AudioFilesSelect<true>;
+    'audio-jobs': AudioJobsSelect<false> | AudioJobsSelect<true>;
+    transcripts: TranscriptsSelect<false> | TranscriptsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -669,6 +675,73 @@ export interface DeviceToken {
   createdAt: string;
 }
 /**
+ * Raw audio uploads. Linked to audio-jobs.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "audio-files".
+ */
+export interface AudioFile {
+  id: number;
+  durationSeconds?: number | null;
+  uploader?: (number | null) | User;
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "audio-jobs".
+ */
+export interface AudioJob {
+  id: number;
+  title: string;
+  kind: 'interview' | 'meeting' | 'presser' | 'lecture' | 'court' | 'other';
+  notes?: string | null;
+  audioFile: number | AudioFile;
+  uploader?: (number | null) | User;
+  status: 'queued' | 'dispatching' | 'processing' | 'completed' | 'failed';
+  externalJobId?: string | null;
+  callbackSecret?: string | null;
+  progress?: number | null;
+  dispatchAttempts?: number | null;
+  error?: string | null;
+  transcribedAt?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * Transcript JSON blobs linked 1:1 with audio-jobs. Edited via the custom audio-jobs admin view, not directly here.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "transcripts".
+ */
+export interface Transcript {
+  id: number;
+  audioJob: number | AudioJob;
+  data:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  searchableText?: string | null;
+  editedAt?: string | null;
+  editedBy?: (number | null) | User;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
@@ -743,6 +816,18 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'device-tokens';
         value: number | DeviceToken;
+      } | null)
+    | ({
+        relationTo: 'audio-files';
+        value: number | AudioFile;
+      } | null)
+    | ({
+        relationTo: 'audio-jobs';
+        value: number | AudioJob;
+      } | null)
+    | ({
+        relationTo: 'transcripts';
+        value: number | Transcript;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -1077,6 +1162,58 @@ export interface DeviceTokensSelect<T extends boolean = true> {
   token?: T;
   platform?: T;
   lastSeenAt?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "audio-files_select".
+ */
+export interface AudioFilesSelect<T extends boolean = true> {
+  durationSeconds?: T;
+  uploader?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  url?: T;
+  thumbnailURL?: T;
+  filename?: T;
+  mimeType?: T;
+  filesize?: T;
+  width?: T;
+  height?: T;
+  focalX?: T;
+  focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "audio-jobs_select".
+ */
+export interface AudioJobsSelect<T extends boolean = true> {
+  title?: T;
+  kind?: T;
+  notes?: T;
+  audioFile?: T;
+  uploader?: T;
+  status?: T;
+  externalJobId?: T;
+  callbackSecret?: T;
+  progress?: T;
+  dispatchAttempts?: T;
+  error?: T;
+  transcribedAt?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "transcripts_select".
+ */
+export interface TranscriptsSelect<T extends boolean = true> {
+  audioJob?: T;
+  data?: T;
+  searchableText?: T;
+  editedAt?: T;
+  editedBy?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -55,6 +55,9 @@ import Logos from './collections/Logos.ts'
 import Seo from './collections/Seo.ts'
 import Theme from './collections/Theme.ts'
 import DeviceTokens from './collections/DeviceTokens.ts'
+import { AudioFiles } from './collections/AudioFiles.ts'
+import { AudioJobs } from './collections/AudioJobs.ts'
+import { Transcripts } from './collections/Transcripts.ts'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -87,7 +90,7 @@ export default buildConfig({
       },
     },
   },
-  collections: [Users, Media, Logos, Articles, LiveArticles, JobTitles, Layout, OpinionPageLayout, FeaturesPageLayout, StaffPageLayout, Submissions, EventSubmissions, DeviceTokens],
+  collections: [Users, Media, Logos, Articles, LiveArticles, JobTitles, Layout, OpinionPageLayout, FeaturesPageLayout, StaffPageLayout, Submissions, EventSubmissions, DeviceTokens, AudioFiles, AudioJobs, Transcripts],
   globals: [Theme, Seo],
   editor: lexicalEditor({
     features: ({ defaultFeatures }) => [

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -87,6 +87,10 @@ export default buildConfig({
         dashboard: {
           Component: '@/components/Dashboard#default',
         },
+        transcribeSearch: {
+          Component: '@/components/Transcribe/Search/SearchView#default',
+          path: '/transcribe/search',
+        },
       },
     },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.32)(happy-dom@20.8.9)(vite@8.0.10(@types/node@20.19.32)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.77.4)(tsx@4.21.0))
 
 packages:
 
@@ -238,14 +241,23 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -810,6 +822,12 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@15.5.12':
     resolution: {integrity: sha512-pUvdJN1on574wQHjaBfNGDt9Mz5utDSZFsIIQkMzPgNS8ZvT4H2mwOrOIClwsQOb6EGx5M76/CZr6G8i6pSpLg==}
 
@@ -959,6 +977,9 @@ packages:
     resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
     engines: {node: '>=14'}
 
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
   '@payloadcms/db-postgres@3.80.0':
     resolution: {integrity: sha512-YeFmnELmnvhSMdDq7kxCxgI6g8JEn+YrFbhLMXAk4Ze7MRDdZz/cB6OSp30gb9uqiDoO6hLbyqnJdhvmeodZHg==}
     peerDependencies:
@@ -1054,8 +1075,109 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -1168,8 +1290,14 @@ packages:
   '@types/busboy@1.5.4':
     resolution: {integrity: sha512-kG7WrUuAKK0NoyxfQHsVE6j1m01s6kMma64E+OZenQABMQyTJop1DumUWcLwAQ2JzpefU7PDYoRDKl8uZosFjw==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/escape-html@1.0.4':
     resolution: {integrity: sha512-qZ72SFTgUAZ5a7Tj6kf2SHLetiH5S6f8G5frB2SPQ3EyF02kxdyBFf4Tz4banE3xCgGnKgWLt//a6VuYHKYJTg==}
@@ -1403,6 +1531,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1470,6 +1627,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -1563,6 +1724,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1874,6 +2039,9 @@ packages:
     resolution: {integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -2029,9 +2197,16 @@ packages:
   estree-util-visit@2.0.0:
     resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-copy@3.0.2:
     resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
@@ -2520,8 +2695,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.30.2:
     resolution: {integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -2532,8 +2719,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.30.2:
     resolution: {integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -2544,8 +2743,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.30.2:
     resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -2558,8 +2770,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -2572,8 +2798,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -2584,8 +2823,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.30.2:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
   lines-and-columns@1.2.4:
@@ -2832,6 +3081,9 @@ packages:
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
@@ -2883,6 +3135,9 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   payload@3.80.0:
     resolution: {integrity: sha512-GcVN0NavtFjDzaivz+yY10skQ9BAzrU/YE4xqykFNDD1gT6sogvTEJBMuEI2dYxIw/J7wDHDaKzzH/g/tWNT0w==}
@@ -2986,6 +3241,10 @@ packages:
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.6:
@@ -3181,6 +3440,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -3266,6 +3530,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   simple-wcswidth@1.1.2:
     resolution: {integrity: sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==}
 
@@ -3303,8 +3570,14 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3393,9 +3666,24 @@ packages:
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-no-case@1.0.2:
     resolution: {integrity: sha512-Z3g735FxuZY8rodxV4gH7LxClE4H0hTIyHNIHdk+vpQxjLm0cwnKXq/OFVZ76SOQmto7txVcwSCwkU5kqp+FKg==}
@@ -3545,6 +3833,90 @@ packages:
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.25.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.8.3
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-vitals@5.1.0:
     resolution: {integrity: sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==}
 
@@ -3571,6 +3943,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3778,9 +4155,20 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.8.1':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -3790,6 +4178,11 @@ snapshots:
     optional: true
 
   '@emnapi/wasi-threads@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -4350,6 +4743,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@next/env@15.5.12': {}
 
   '@next/env@16.1.7': {}
@@ -4471,6 +4871,8 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@oxc-project/types@0.127.0': {}
 
   '@payloadcms/db-postgres@3.80.0(@opentelemetry/api@1.9.0)(payload@3.80.0(graphql@16.12.0)(typescript@5.9.3))':
     dependencies:
@@ -4717,7 +5119,60 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
+
   '@rtsao/scc@1.1.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -4814,9 +5269,16 @@ snapshots:
     dependencies:
       '@types/node': 20.19.32
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/escape-html@1.0.4': {}
 
@@ -5037,6 +5499,47 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@20.19.32)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.77.4)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10(@types/node@20.19.32)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.77.4)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -5139,6 +5642,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -5223,6 +5728,8 @@ snapshots:
   caniuse-lite@1.0.30001769: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -5504,6 +6011,8 @@ snapshots:
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
 
+  es-module-lexer@2.1.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -5775,7 +6284,13 @@ snapshots:
       '@types/estree-jsx': 1.0.5
       '@types/unist': 3.0.3
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   fast-copy@3.0.2: {}
 
@@ -6243,34 +6758,67 @@ snapshots:
   lightningcss-android-arm64@1.30.2:
     optional: true
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-x64@1.30.2:
     optional: true
 
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.30.2:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.30.2:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.30.2:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.30.2:
     optional: true
 
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.30.2:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.30.2:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
     optional: true
 
   lightningcss@1.30.2:
@@ -6288,6 +6836,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.30.2
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lines-and-columns@1.2.4: {}
 
@@ -6664,6 +7228,8 @@ snapshots:
 
   obuf@1.1.2: {}
 
+  obug@2.1.1: {}
+
   on-exit-leak-free@2.1.2: {}
 
   once@1.4.0:
@@ -6723,6 +7289,8 @@ snapshots:
   path-to-regexp@6.3.0: {}
 
   path-type@4.0.0: {}
+
+  pathe@2.0.3: {}
 
   payload@3.80.0(graphql@16.12.0)(typescript@5.9.3):
     dependencies:
@@ -6880,6 +7448,12 @@ snapshots:
   possible-typed-array-names@1.1.0: {}
 
   postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -7090,6 +7664,27 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -7222,6 +7817,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   simple-wcswidth@1.1.2: {}
 
   sisteransi@1.0.5: {}
@@ -7250,7 +7847,11 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  stackback@0.0.2: {}
+
   state-local@1.0.7: {}
+
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -7349,10 +7950,21 @@ snapshots:
     dependencies:
       real-require: 0.2.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.1: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   to-no-case@1.0.2: {}
 
@@ -7544,6 +8156,50 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-stringify-position: 4.0.0
 
+  vite@8.0.10(@types/node@20.19.32)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.77.4)(tsx@4.21.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.12
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 20.19.32
+      esbuild: 0.25.12
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      sass: 1.77.4
+      tsx: 4.21.0
+
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.32)(happy-dom@20.8.9)(vite@8.0.10(@types/node@20.19.32)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.77.4)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@20.19.32)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.77.4)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@20.19.32)(esbuild@0.25.12)(jiti@2.6.1)(sass@1.77.4)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 20.19.32
+      happy-dom: 20.8.9
+    transitivePeerDependencies:
+      - msw
+
   web-vitals@5.1.0: {}
 
   whatwg-mimetype@3.0.0: {}
@@ -7592,6 +8248,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      react-window:
+        specifier: ^2.2.7
+        version: 2.2.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -104,6 +107,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.13)
+      '@types/react-window':
+        specifier: ^2.0.0
+        version: 2.0.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       eslint:
         specifier: ^9
         version: 9.39.2(jiti@2.6.1)
@@ -1347,6 +1353,10 @@ packages:
     resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
     peerDependencies:
       '@types/react': '*'
+
+  '@types/react-window@2.0.0':
+    resolution: {integrity: sha512-E8hMDtImEpMk1SjswSvqoSmYvk7GEtyVaTa/GJV++FdDNuMVVEzpAClyJ0nqeKYBrMkGiyH6M1+rPLM0Nu1exQ==}
+    deprecated: This is a stub types definition. react-window provides its own type definitions, so you do not need this installed.
 
   '@types/react@19.2.13':
     resolution: {integrity: sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==}
@@ -3396,6 +3406,12 @@ packages:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
 
+  react-window@2.2.7:
+    resolution: {integrity: sha512-SH5nvfUQwGHYyriDUAOt7wfPsfG9Qxd6OdzQxl5oQ4dsSsUicqQvjV7dR+NqZ4coY0fUn3w1jnC5PwzIUWEg5w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
@@ -5329,6 +5345,13 @@ snapshots:
   '@types/react-transition-group@4.4.12(@types/react@19.2.13)':
     dependencies:
       '@types/react': 19.2.13
+
+  '@types/react-window@2.0.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      react-window: 2.2.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   '@types/react@19.2.13':
     dependencies:
@@ -7613,6 +7636,11 @@ snapshots:
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
+  react-window@2.2.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 

--- a/scripts/generate-env.js
+++ b/scripts/generate-env.js
@@ -14,6 +14,14 @@ NEXT_PUBLIC_POSTHOG_KEY=
 # LEGACY_DATABASE_URI=postgres://user:password@host:port/legacy_database_name
 # NEXT_PUBLIC_SITE_URL=http://localhost:3000
 # NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+# Audio transcription service (homelab GPU box behind Cloudflare Tunnel).
+# Leave blank to disable transcription locally.
+TRANSCRIBE_API_URL=
+TRANSCRIBE_API_KEY=
+TRANSCRIBE_CF_ACCESS_CLIENT_ID=
+TRANSCRIBE_CF_ACCESS_CLIENT_SECRET=
+TRANSCRIBE_PUBLIC_BASE_URL=http://localhost:3000
+AUDIO_DIR=/var/www/polymer-media/audio
 `;
 
   fs.writeFileSync(envPath, content);

--- a/scripts/run_deploy_sql_migrations.sh
+++ b/scripts/run_deploy_sql_migrations.sh
@@ -1245,4 +1245,107 @@ ALTER TABLE "media" ADD COLUMN IF NOT EXISTS "sizes_card_height" numeric;
 ALTER TABLE "media" ADD COLUMN IF NOT EXISTS "sizes_card_mime_type" varchar;
 ALTER TABLE "media" ADD COLUMN IF NOT EXISTS "sizes_card_filesize" numeric;
 ALTER TABLE "media" ADD COLUMN IF NOT EXISTS "sizes_card_filename" varchar;
+
+-- 20260428_100000: Audio transcription tables (audio_files, audio_jobs, transcripts) + enums + locked-rels columns
+DO $$ BEGIN
+  CREATE TYPE "public"."enum_audio_jobs_kind" AS ENUM('interview','meeting','presser','lecture','court','other');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  CREATE TYPE "public"."enum_audio_jobs_status" AS ENUM('queued','dispatching','processing','completed','failed');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS "audio_files" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "duration_seconds" numeric,
+  "uploader_id" integer,
+  "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  "url" varchar,
+  "thumbnail_u_r_l" varchar,
+  "filename" varchar,
+  "mime_type" varchar,
+  "filesize" numeric,
+  "width" numeric,
+  "height" numeric,
+  "focal_x" numeric,
+  "focal_y" numeric
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "audio_files_filename_idx" ON "audio_files" USING btree ("filename");
+CREATE INDEX IF NOT EXISTS "audio_files_uploader_idx" ON "audio_files" USING btree ("uploader_id");
+CREATE INDEX IF NOT EXISTS "audio_files_created_at_idx" ON "audio_files" USING btree ("created_at");
+DO $$ BEGIN
+  ALTER TABLE "audio_files" ADD CONSTRAINT "audio_files_uploader_id_users_id_fk"
+    FOREIGN KEY ("uploader_id") REFERENCES "public"."users"("id") ON DELETE SET NULL;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS "audio_jobs" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "title" varchar NOT NULL,
+  "kind" "public"."enum_audio_jobs_kind" NOT NULL DEFAULT 'interview',
+  "notes" varchar,
+  "audio_file_id" integer NOT NULL,
+  "uploader_id" integer,
+  "status" "public"."enum_audio_jobs_status" NOT NULL DEFAULT 'queued',
+  "external_job_id" varchar,
+  "callback_secret" varchar,
+  "progress" numeric,
+  "dispatch_attempts" numeric DEFAULT 0,
+  "error" varchar,
+  "transcribed_at" timestamp(3) with time zone,
+  "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+);
+CREATE INDEX IF NOT EXISTS "audio_jobs_status_idx" ON "audio_jobs" USING btree ("status");
+CREATE INDEX IF NOT EXISTS "audio_jobs_uploader_idx" ON "audio_jobs" USING btree ("uploader_id");
+CREATE INDEX IF NOT EXISTS "audio_jobs_created_at_idx" ON "audio_jobs" USING btree ("created_at");
+CREATE UNIQUE INDEX IF NOT EXISTS "audio_jobs_external_job_id_idx" ON "audio_jobs" USING btree ("external_job_id") WHERE "external_job_id" IS NOT NULL;
+DO $$ BEGIN
+  ALTER TABLE "audio_jobs" ADD CONSTRAINT "audio_jobs_audio_file_id_audio_files_id_fk"
+    FOREIGN KEY ("audio_file_id") REFERENCES "public"."audio_files"("id") ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE "audio_jobs" ADD CONSTRAINT "audio_jobs_uploader_id_users_id_fk"
+    FOREIGN KEY ("uploader_id") REFERENCES "public"."users"("id") ON DELETE SET NULL;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS "transcripts" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "audio_job_id" integer NOT NULL,
+  "data" jsonb NOT NULL,
+  "searchable_text" text,
+  "edited_at" timestamp(3) with time zone,
+  "edited_by_id" integer,
+  "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "transcripts_audio_job_idx" ON "transcripts" USING btree ("audio_job_id");
+CREATE INDEX IF NOT EXISTS "transcripts_searchable_text_fts_idx" ON "transcripts"
+  USING gin (to_tsvector('english', coalesce("searchable_text", '')));
+DO $$ BEGIN
+  ALTER TABLE "transcripts" ADD CONSTRAINT "transcripts_audio_job_id_audio_jobs_id_fk"
+    FOREIGN KEY ("audio_job_id") REFERENCES "public"."audio_jobs"("id") ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE "transcripts" ADD CONSTRAINT "transcripts_edited_by_id_users_id_fk"
+    FOREIGN KEY ("edited_by_id") REFERENCES "public"."users"("id") ON DELETE SET NULL;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+ALTER TABLE "payload_locked_documents_rels" ADD COLUMN IF NOT EXISTS "audio_files_id" integer;
+ALTER TABLE "payload_locked_documents_rels" ADD COLUMN IF NOT EXISTS "audio_jobs_id" integer;
+ALTER TABLE "payload_locked_documents_rels" ADD COLUMN IF NOT EXISTS "transcripts_id" integer;
+DO $$ BEGIN
+  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_audio_files_fk"
+    FOREIGN KEY ("audio_files_id") REFERENCES "public"."audio_files"("id") ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_audio_jobs_fk"
+    FOREIGN KEY ("audio_jobs_id") REFERENCES "public"."audio_jobs"("id") ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_transcripts_fk"
+    FOREIGN KEY ("transcripts_id") REFERENCES "public"."transcripts"("id") ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_audio_files_id_idx" ON "payload_locked_documents_rels" ("audio_files_id");
+CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_audio_jobs_id_idx" ON "payload_locked_documents_rels" ("audio_jobs_id");
+CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_transcripts_id_idx" ON "payload_locked_documents_rels" ("transcripts_id");
 SQL

--- a/tests/lib/transcribe/exporters.test.ts
+++ b/tests/lib/transcribe/exporters.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildPlainText,
+  buildSrt,
+  buildVtt,
+  buildJson,
+} from '../../../lib/transcribe/exporters'
+import type { TranscriptData } from '../../../lib/transcribe/types'
+
+const data: TranscriptData = {
+  language: 'en',
+  duration: 10,
+  model: 't',
+  speakers: [
+    { id: 'SPEAKER_00', label: 'Mayor' },
+    { id: 'SPEAKER_01', label: null },
+  ],
+  segments: [
+    { id: 'seg_0001', speakerId: 'SPEAKER_00', start: 0, end: 2.5, text: 'Hello.', words: [] },
+    { id: 'seg_0002', speakerId: 'SPEAKER_01', start: 2.5, end: 5, text: 'Hi.', words: [] },
+  ],
+}
+
+describe('buildPlainText', () => {
+  it('formats with speakers by default', () => {
+    expect(buildPlainText(data)).toBe('Mayor: Hello.\n\nSPEAKER_01: Hi.\n')
+  })
+  it('omits speakers when asked', () => {
+    expect(buildPlainText(data, false)).toBe('Hello.\n\nHi.\n')
+  })
+})
+
+describe('buildSrt', () => {
+  it('produces valid SRT cues', () => {
+    const out = buildSrt(data)
+    expect(out).toContain('1\n00:00:00,000 --> 00:00:02,500\nMayor: Hello.')
+    expect(out).toContain('2\n00:00:02,500 --> 00:00:05,000\nSPEAKER_01: Hi.')
+  })
+})
+
+describe('buildVtt', () => {
+  it('produces WebVTT with speaker tags', () => {
+    const out = buildVtt(data)
+    expect(out.startsWith('WEBVTT')).toBe(true)
+    expect(out).toContain('00:00:00.000 --> 00:00:02.500')
+    expect(out).toContain('<v Mayor>Hello.')
+    expect(out).toContain('<v SPEAKER_01>Hi.')
+  })
+})
+
+describe('buildJson', () => {
+  it('round-trips data as JSON', () => {
+    expect(JSON.parse(buildJson(data))).toEqual(data)
+  })
+})

--- a/tests/lib/transcribe/highlight.test.ts
+++ b/tests/lib/transcribe/highlight.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { findMatchRanges, tokenizeQuery } from '../../../lib/transcribe/highlight'
+
+describe('tokenizeQuery', () => {
+  it('splits whitespace-separated terms', () => {
+    expect(tokenizeQuery('hello world')).toEqual(['hello', 'world'])
+  })
+  it('preserves double-quoted phrases', () => {
+    expect(tokenizeQuery('"city council" budget')).toEqual(['city council', 'budget'])
+  })
+  it('preserves single-quoted phrases', () => {
+    expect(tokenizeQuery("'rainy day' fund")).toEqual(['rainy day', 'fund'])
+  })
+  it('returns empty array for empty input', () => {
+    expect(tokenizeQuery('   ')).toEqual([])
+  })
+})
+
+describe('findMatchRanges', () => {
+  it('returns empty for empty query or text', () => {
+    expect(findMatchRanges('hello', '')).toEqual([])
+    expect(findMatchRanges('', 'hello')).toEqual([])
+  })
+
+  it('finds a single term, case-insensitive', () => {
+    expect(findMatchRanges('Hello world', 'hello')).toEqual([{ start: 0, end: 5 }])
+  })
+
+  it('honors case-sensitive flag', () => {
+    expect(findMatchRanges('Hello world', 'hello', { caseSensitive: true })).toEqual([])
+  })
+
+  it('finds multiple terms and sorts ranges', () => {
+    expect(findMatchRanges('cat dog cat', 'cat dog')).toEqual([
+      { start: 0, end: 3 },
+      { start: 4, end: 7 },
+      { start: 8, end: 11 },
+    ])
+  })
+
+  it('merges overlapping ranges from different terms', () => {
+    // 'hello' matches [0, 5], 'hell' matches [0, 4] — should merge to [0, 5]
+    expect(findMatchRanges('hello world', 'hello hell')).toEqual([
+      { start: 0, end: 5 },
+    ])
+  })
+
+  it('merges adjacent ranges', () => {
+    // 'aab' at 0, 'aab' at 3 → adjacent → merged to [0, 6]
+    expect(findMatchRanges('aabaab', 'aab')).toEqual([{ start: 0, end: 6 }])
+  })
+
+  it('escapes regex metacharacters in terms', () => {
+    expect(findMatchRanges('a.b a.b', 'a.b')).toEqual([
+      { start: 0, end: 3 },
+      { start: 4, end: 7 },
+    ])
+  })
+})

--- a/tests/lib/transcribe/hmac.test.ts
+++ b/tests/lib/transcribe/hmac.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { signBody, verifySignature } from '../../../lib/transcribe/hmac'
+
+describe('signBody', () => {
+  it('produces a deterministic hex digest', () => {
+    expect(signBody('hello', 'secret')).toBe(
+      '88aab3ede8d3adf94d26ab90d3bafd4a2083070c3bcce9c014ee04a443847c0b',
+    )
+  })
+
+  it('handles Buffer input identically to string', () => {
+    expect(signBody(Buffer.from('hello'), 'secret')).toBe(signBody('hello', 'secret'))
+  })
+})
+
+describe('verifySignature', () => {
+  const body = JSON.stringify({ job_id: 'abc', status: 'completed' })
+  const secret = 'a-shared-secret'
+
+  it('accepts a valid sha256= prefixed signature', () => {
+    const sig = `sha256=${signBody(body, secret)}`
+    expect(verifySignature(body, sig, secret)).toBe(true)
+  })
+
+  it('accepts a valid bare signature', () => {
+    expect(verifySignature(body, signBody(body, secret), secret)).toBe(true)
+  })
+
+  it('rejects a tampered body', () => {
+    const sig = signBody(body, secret)
+    expect(verifySignature(body + 'x', sig, secret)).toBe(false)
+  })
+
+  it('rejects a wrong secret', () => {
+    const sig = signBody(body, 'other')
+    expect(verifySignature(body, sig, secret)).toBe(false)
+  })
+
+  it('rejects null/undefined header', () => {
+    expect(verifySignature(body, null, secret)).toBe(false)
+    expect(verifySignature(body, undefined, secret)).toBe(false)
+  })
+
+  it('rejects malformed hex', () => {
+    expect(verifySignature(body, 'sha256=zzzz', secret)).toBe(false)
+  })
+
+  it('rejects wrong-length signature', () => {
+    expect(verifySignature(body, 'sha256=deadbeef', secret)).toBe(false)
+  })
+})

--- a/tests/lib/transcribe/segments.test.ts
+++ b/tests/lib/transcribe/segments.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import {
+  mergeSegments,
+  splitSegment,
+  reassignSpeaker,
+  nextSegmentId,
+} from '../../../lib/transcribe/segments'
+import type { TranscriptData } from '../../../lib/transcribe/types'
+
+const sample: TranscriptData = {
+  language: 'en',
+  duration: 30,
+  model: 'test',
+  speakers: [
+    { id: 'SPEAKER_00', label: null },
+    { id: 'SPEAKER_01', label: null },
+  ],
+  segments: [
+    {
+      id: 'seg_0001',
+      speakerId: 'SPEAKER_00',
+      start: 0,
+      end: 5,
+      text: 'Hello there friend.',
+      words: [
+        { word: 'Hello', start: 0, end: 1 },
+        { word: 'there', start: 1, end: 2 },
+        { word: 'friend.', start: 2, end: 3 },
+      ],
+    },
+    {
+      id: 'seg_0002',
+      speakerId: 'SPEAKER_01',
+      start: 5,
+      end: 10,
+      text: 'How are you?',
+      words: [
+        { word: 'How', start: 5, end: 6 },
+        { word: 'are', start: 6, end: 7 },
+        { word: 'you?', start: 7, end: 8 },
+      ],
+    },
+  ],
+}
+
+describe('nextSegmentId', () => {
+  it('returns the next zero-padded id', () => {
+    expect(nextSegmentId(sample.segments)).toBe('seg_0003')
+  })
+
+  it('handles empty segment list', () => {
+    expect(nextSegmentId([])).toBe('seg_0001')
+  })
+})
+
+describe('mergeSegments', () => {
+  it('merges two adjacent segments', () => {
+    const out = mergeSegments(sample, 'seg_0001', 'seg_0002')
+    expect(out.segments).toHaveLength(1)
+    expect(out.segments[0].id).toBe('seg_0001')
+    expect(out.segments[0].text).toBe('Hello there friend. How are you?')
+    expect(out.segments[0].start).toBe(0)
+    expect(out.segments[0].end).toBe(10)
+    expect(out.segments[0].words).toHaveLength(6)
+    expect(out.segments[0].edited).toBe(true)
+  })
+
+  it('refuses to merge non-adjacent segments', () => {
+    const three: TranscriptData = {
+      ...sample,
+      segments: [
+        ...sample.segments,
+        {
+          id: 'seg_0003',
+          speakerId: 'SPEAKER_00',
+          start: 10,
+          end: 15,
+          text: 'Bye.',
+          words: [],
+        },
+      ],
+    }
+    const out = mergeSegments(three, 'seg_0001', 'seg_0003')
+    expect(out.segments).toHaveLength(3)
+  })
+
+  it('returns data unchanged when an id is missing', () => {
+    const out = mergeSegments(sample, 'seg_0001', 'seg_9999')
+    expect(out).toBe(sample)
+  })
+})
+
+describe('splitSegment', () => {
+  it('splits a segment at a middle word index', () => {
+    const out = splitSegment(sample, 'seg_0001', 2)
+    expect(out.segments).toHaveLength(3)
+    expect(out.segments[0].id).toBe('seg_0001')
+    expect(out.segments[0].text).toBe('Hello there')
+    expect(out.segments[0].end).toBe(2)
+    expect(out.segments[0].edited).toBe(true)
+    expect(out.segments[1].id).toBe('seg_0003')
+    expect(out.segments[1].text).toBe('friend.')
+    expect(out.segments[1].start).toBe(2)
+    expect(out.segments[1].edited).toBe(true)
+  })
+
+  it('refuses to split at the start or end', () => {
+    expect(splitSegment(sample, 'seg_0001', 0).segments).toHaveLength(2)
+    expect(splitSegment(sample, 'seg_0001', 3).segments).toHaveLength(2)
+  })
+
+  it('returns data unchanged for unknown segment id', () => {
+    expect(splitSegment(sample, 'seg_9999', 1)).toBe(sample)
+  })
+})
+
+describe('reassignSpeaker', () => {
+  it('reassigns to existing speaker without growing speaker list', () => {
+    const out = reassignSpeaker(sample, 'seg_0001', 'SPEAKER_01')
+    expect(out.segments[0].speakerId).toBe('SPEAKER_01')
+    expect(out.speakers).toHaveLength(2)
+  })
+
+  it('adds a new speaker when target id is unknown', () => {
+    const out = reassignSpeaker(sample, 'seg_0001', 'SPEAKER_02')
+    expect(out.speakers).toHaveLength(3)
+    expect(out.speakers[2]).toEqual({ id: 'SPEAKER_02', label: null })
+    expect(out.segments[0].speakerId).toBe('SPEAKER_02')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+import path from 'node:path'
+
+export default defineConfig({
+  test: {
+    include: ['tests/lib/**/*.test.ts'],
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Adds audio upload + async high-accuracy transcription with speaker diarization, accessible via a fully custom Payload admin UI for writers, editors, EIC, and admins. Use cases: interviews, meetings, press conferences, lectures, court hearings.

Two services:

- **polymer (this PR)** — three new collections (`audio-files`, `audio-jobs`, `transcripts`), upload + dispatch + webhook routes, custom Payload admin views (list, upload modal, status panel, full transcript editor, search), Postgres FTS.
- **polymer-transcribe (separate repo on homelab)** — FastAPI + WhisperX large-v3 + pyannote-3.1 on an RTX 4070, exposed via Cloudflare Tunnel + CF Access service token. Build prompt at `docs/superpowers/specs/2026-04-28-polymer-transcribe-prompt.md`.

Spec: `docs/superpowers/specs/2026-04-28-audio-transcription-design.md`
Plan: `docs/superpowers/plans/2026-04-28-audio-transcription.md`

### Editor features
- Audio playback with word-level seek and current-word highlighting
- Speaker rename + reassign
- Inline text editing per segment
- Segment merge (↑/↓ buttons) and split (alt-click a word)
- Find & Replace (regex + case-sensitive toggles)
- Export to TXT / SRT / VTT / JSON
- 2 s debounced auto-save
- Virtualized segment list (handles thousands of segments)

### Search
- Postgres `tsvector` GIN index on transcript text
- `websearch_to_tsquery` parsing, `ts_rank` ordering
- Range-based snippet highlighting (no HTML injection)
- Role-scoped: writers see own; editors/EIC/admin see all

### Security model on the dispatch path
- Cloudflare Tunnel (no inbound homelab ports)
- Cloudflare Access service-token (`CF-Access-Client-Id` + `Secret`) at the edge
- Bearer `TRANSCRIBE_API_KEY` checked by the FastAPI app
- HMAC-SHA256 webhook signature with per-job random `callbackSecret`

### Migration
- TS migration in `migrations/20260428_100000_add_audio_transcription.ts`
- SQL block + tracking insert appended to `scripts/run_deploy_sql_migrations.sh`

### Deploy
- 5 new GitHub secrets: `TRANSCRIBE_API_URL`, `TRANSCRIBE_API_KEY`, `TRANSCRIBE_CF_ACCESS_CLIENT_ID`, `TRANSCRIBE_CF_ACCESS_CLIENT_SECRET`, `TRANSCRIBE_PUBLIC_BASE_URL` (already set)
- `.github/workflows/deploy.yml` writes them into shared `.env`
- Prod VM needs `ffmpeg` + `ffprobe` (`pacman -S ffmpeg`)

### Known follow-ups
- The CF Access service-token shared in chat must be rotated before this is trusted in prod
- The homelab `polymer-transcribe` repo is built separately from the prompt above

## Test plan

- [ ] CI passes (lint, typecheck, build, migrate)
- [ ] `pnpm test:unit` — 35 unit tests (hmac, segments, exporters, highlight)
- [ ] `pnpm db:fresh` applies the new migration cleanly
- [ ] Smoke locally: log in as writer, upload <10s audio, status panel polls, simulate webhook with HMAC, editor renders, exercise rename/edit/merge/split/find/replace/export
- [ ] After homelab is live: real 5-min, 30-min, 2-hr samples via the live tunnel
- [ ] Verify rotated CF Access secret before merging to main / triggering deploy