### PR TITLE
fix: stream audio upload to bound memory

### DIFF
--- a/app/api/transcribe/upload/route.ts
+++ b/app/api/transcribe/upload/route.ts
@@ -1,9 +1,13 @@
 import { NextResponse } from 'next/server'
 import { getPayload } from 'payload'
 import { randomBytes } from 'node:crypto'
-import { mkdtemp, writeFile, rm, unlink } from 'node:fs/promises'
+import { mkdtemp, rm, unlink, readFile, stat } from 'node:fs/promises'
+import { createWriteStream } from 'node:fs'
+import { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
 import path from 'node:path'
 import os from 'node:os'
+import Busboy from 'busboy'
 import config from '@/payload.config'
 import { ffprobe, transcodeToOpus } from '@/lib/transcribe/ffmpeg'
 import { dispatchToTranscribeApi } from '@/lib/transcribe/dispatch'
@@ -13,7 +17,84 @@ const MAX_HOURS = 6
 const STAFF_ROLES = ['admin', 'eic', 'editor', 'writer']
 
 export const dynamic = 'force-dynamic'
-export const maxDuration = 300
+export const maxDuration = 1800
+
+interface ParsedUpload {
+  audioPath: string
+  audioName: string
+  audioMimeType: string
+  title?: string
+  kind?: string
+  notes?: string
+}
+
+async function parseMultipart(req: Request, tmpDir: string): Promise<ParsedUpload> {
+  if (!req.body) throw new Error('request has no body')
+
+  const headers = Object.fromEntries(req.headers) as Record<string, string>
+  const bb = Busboy({ headers })
+  const fields: Record<string, string> = {}
+  let audioPath: string | undefined
+  let audioName: string | undefined
+  let audioMimeType: string | undefined
+
+  const nodeStream = Readable.fromWeb(req.body as Parameters<typeof Readable.fromWeb>[0])
+
+  await new Promise<void>((resolve, reject) => {
+    let pendingFile: Promise<void> | null = null
+    let settled = false
+    const settle = (fn: () => void) => {
+      if (settled) return
+      settled = true
+      fn()
+    }
+
+    bb.on('file', (name, file, info) => {
+      if (name !== 'audio') {
+        file.resume()
+        return
+      }
+      audioName = info.filename || 'upload.bin'
+      audioMimeType = info.mimeType || 'application/octet-stream'
+      const dest = path.join(tmpDir, audioName)
+      audioPath = dest
+      pendingFile = pipeline(file, createWriteStream(dest)).catch((err) => {
+        settle(() => reject(err))
+        throw err
+      })
+    })
+
+    bb.on('field', (name, value) => {
+      fields[name] = value
+    })
+
+    bb.on('error', (err) => {
+      settle(() => reject(err instanceof Error ? err : new Error(String(err))))
+    })
+
+    bb.on('finish', () => {
+      Promise.resolve(pendingFile)
+        .then(() => settle(() => resolve()))
+        .catch((err) => settle(() => reject(err)))
+    })
+
+    nodeStream.on('error', (err) => settle(() => reject(err)))
+    nodeStream.pipe(bb)
+  })
+
+  if (!audioPath || !audioName || !audioMimeType) {
+    throw new Error('audio file required')
+  }
+
+  return {
+    audioPath,
+    audioName,
+    audioMimeType,
+    title: fields.title,
+    kind: fields.kind,
+    notes: fields.notes,
+  }
+}
 
 export async function POST(req: Request) {
   const payload = await getPayload({ config })
@@ -24,20 +105,23 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'forbidden' }, { status: 403 })
   }
 
-  const form = await req.formData()
-  const audio = form.get('audio')
-  if (!(audio instanceof File)) {
-    return NextResponse.json({ error: 'audio file required' }, { status: 400 })
-  }
-  const title = String(form.get('title') ?? audio.name)
-  const kind = String(form.get('kind') ?? 'interview')
-  const notesRaw = form.get('notes')
-  const notes = typeof notesRaw === 'string' && notesRaw.length > 0 ? notesRaw : undefined
-
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'polymer-upload-'))
-  const tmpPath = path.join(tmpDir, audio.name)
-  const audioBuffer = Buffer.from(await audio.arrayBuffer())
-  await writeFile(tmpPath, audioBuffer)
+
+  let parsed: ParsedUpload
+  try {
+    parsed = await parseMultipart(req, tmpDir)
+  } catch (err) {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {})
+    const message = err instanceof Error ? err.message : 'invalid upload'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+
+  const tmpPath = parsed.audioPath
+  const audioName = parsed.audioName
+  const audioMimeType = parsed.audioMimeType
+  const title = parsed.title ?? audioName
+  const kind = parsed.kind ?? 'interview'
+  const notes = parsed.notes && parsed.notes.length > 0 ? parsed.notes : undefined
 
   try {
     const probe = await ffprobe(tmpPath)
@@ -51,13 +135,16 @@ export async function POST(req: Request) {
       )
     }
 
+    const fileStat = await stat(tmpPath)
+    const fileBuffer = await readFile(tmpPath)
+
     const audioFile = await payload.create({
       collection: 'audio-files',
       file: {
-        data: audioBuffer,
-        mimetype: audio.type || 'application/octet-stream',
-        name: audio.name,
-        size: audio.size,
+        data: fileBuffer,
+        mimetype: audioMimeType,
+        name: audioName,
+        size: fileStat.size,
       },
       data: {
         durationSeconds: probe.durationSeconds,
@@ -85,7 +172,7 @@ export async function POST(req: Request) {
       audioJobId,
       audioFilePath: tmpPath,
       tmpDir,
-      audioMimeType: audio.type || 'application/octet-stream',
+      audioMimeType,
       callbackSecret,
     })
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@payloadcms/ui": "^3.80.0",
     "@types/pg": "^8.18.0",
     "axios": "^1.13.5",
+    "busboy": "^1.6.0",
     "escape-html": "^1.0.3",
     "graphql": "^16.12.0",
     "lucide-react": "^0.563.0",
@@ -51,6 +52,7 @@
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
+    "@types/busboy": "^1.5.4",
     "@types/escape-html": "^1.0.4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       axios:
         specifier: ^1.13.5
         version: 1.13.5
+      busboy:
+        specifier: ^1.6.0
+        version: 1.6.0
       escape-html:
         specifier: ^1.0.3
         version: 1.0.3
@@ -95,6 +98,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.18
+      '@types/busboy':
+        specifier: ^1.5.4
+        version: 1.5.4
       '@types/escape-html':
         specifier: ^1.0.4
         version: 1.0.4


### PR DESCRIPTION
## Summary

`POST /api/transcribe/upload` was OOMing on 800-900 MB audio uploads because it buffered the entire request body twice in memory:

```ts
const form = await req.formData()                       // copy 1: ~900 MB
...
const audioBuffer = Buffer.from(await audio.arrayBuffer())  // copy 2: ~900 MB
await writeFile(tmpPath, audioBuffer)
```

Peak resident memory hit ~1.6 GB per upload, killing the production process.

## Fix

Switch the multipart parser from `req.formData()` to a streaming `busboy` pipeline:

- `req.body` (Web `ReadableStream`) → `Readable.fromWeb` → busboy
- audio file part is piped straight to `fs.createWriteStream(tmpPath)` via `pipeline()` — bytes never accumulate in JS memory
- small text fields (`title`, `kind`, `notes`) captured from busboy `field` events
- Payload v3.75's `File.data` is typed as `Buffer`, so just before `payload.create` we `readFile(tmpPath)` once. That's still one buffer instead of three, and only happens after we've already streamed to disk + ffprobed.
- `maxDuration` bumped from 300s → 1800s to match the new nginx 1800s upload timeout (slow clients streaming 900 MB can keep the route alive that long).

Memory profile during upload is now constant (kilobytes of busboy/pipeline buffers), regardless of file size. The brief `readFile` spike right before `payload.create` is unavoidable until Payload accepts a Readable for `file.data`, but it happens after the full body is on disk and fully validated.

This unblocks 800-900 MB recording uploads end-to-end (nginx limit was already raised to 1024M / 1800s on the host).

## Verification

Ran locally on this branch:

- [x] `pnpm install` — adds `busboy` + `@types/busboy`
- [x] `pnpm lint` — no new warnings/errors in the route
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — clean (built against a local `polymer2` DB; route compiles into the production bundle)

## Notes

- Auth check unchanged.
- `ffprobe` + `MAX_HOURS = 6` check unchanged.
- `audio-files` / `audio-jobs` create calls unchanged (same shape, same fields).
- `dispatchInBackground` + temp-dir cleanup paths unchanged.
- Response shape unchanged: `{ id, status: 'queued' }` at 201.
- No other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)